### PR TITLE
Re-add old Coincap rates (legacy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # edge-exchange-plugins
 
+# 0.5.4 (2019-04-09)
+
+- Add exchange rates from Coincap *legacy* API
+
 # 0.5.3 (2019-02-26)
 
 - Move ChangeNow into this repo for CORS reasons
+- Migrate Coincap to new API
 
 # 0.5.2 (2019-02-21)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-exchange-plugins",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Exchange-rate sources for the Edge core",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 // @flow
 
-import { makeChangeNowPlugin } from './plugins/changenow.js'
 import { makeChangellyPlugin } from './plugins/changelly.js'
+import { makeChangeNowPlugin } from './plugins/changenow.js'
 import { makeCoinbasePlugin } from './plugins/coinbase.js'
 import { makeCoincapPlugin } from './plugins/coincap.js'
+import { makeCoincapLegacyPlugin } from './plugins/coincapLegacy.js'
 import { makeCurrencyconverterapiPlugin } from './plugins/currencyconverterapi.js'
 import { makeHercPlugin } from './plugins/herc.js'
 import { makeShapeshiftPlugin } from './plugins/shapeshift.js'
@@ -14,6 +15,7 @@ const edgeCorePlugins = {
   changenow: makeChangeNowPlugin,
   coinbase: makeCoinbasePlugin,
   coincap: makeCoincapPlugin,
+  coincapLegacy: makeCoincapLegacyPlugin,
   currencyconverterapi: makeCurrencyconverterapiPlugin,
   herc: makeHercPlugin
 }

--- a/src/plugins/coincapLegacy.js
+++ b/src/plugins/coincapLegacy.js
@@ -5,6 +5,21 @@ import {
   type EdgeRatePlugin
 } from 'edge-core-js/types'
 
+const currencyCodesToInclude = [
+  'FTC',
+  'UFO',
+  'GRS',
+  'SMART',
+  'IND',
+  'HUR',
+  'STORJ',
+  'USDS',
+  'GNO',
+  'NEXO',
+  'FUN',
+  'KIN'
+]
+
 export function makeCoincapLegacyPlugin (
   opts: EdgeCorePluginOptions
 ): EdgeRatePlugin {
@@ -25,7 +40,7 @@ export function makeCoincapLegacyPlugin (
         if (typeof entry.short !== 'string') continue
         if (typeof entry.price !== 'number') continue
         const currency = entry.short
-
+        if (!currencyCodesToInclude.includes(currency)) continue
         pairs.push({
           fromCurrency: currency,
           toCurrency: 'iso:USD',

--- a/src/plugins/coincapLegacy.js
+++ b/src/plugins/coincapLegacy.js
@@ -1,0 +1,39 @@
+// @flow
+
+import {
+  type EdgeCorePluginOptions,
+  type EdgeRatePlugin
+} from 'edge-core-js/types'
+
+export function makeCoincapLegacyPlugin (
+  opts: EdgeCorePluginOptions
+): EdgeRatePlugin {
+  const { io } = opts
+
+  return {
+    rateInfo: {
+      displayName: 'CoincapLegacy'
+    },
+
+    async fetchRates (pairsHint) {
+      const reply = await io.fetch('https://coincap.io/front')
+      const json = await reply.json()
+
+      // Grab all the pairs which are in USD:
+      const pairs = []
+      for (const entry of json) {
+        if (typeof entry.short !== 'string') continue
+        if (typeof entry.price !== 'number') continue
+        const currency = entry.short
+
+        pairs.push({
+          fromCurrency: currency,
+          toCurrency: 'iso:USD',
+          rate: entry.price
+        })
+      }
+
+      return pairs
+    }
+  }
+}


### PR DESCRIPTION
The purpose of this task is to add back the legacy API / exchange rates for Coincap so that the exchange rates that are missing from the newer API can be used within the GUI.