### PR TITLE
Implement same-wallet error throwing for Totle

### DIFF
--- a/src/swap/totle.js
+++ b/src/swap/totle.js
@@ -145,6 +145,12 @@ export function makeTotlePlugin (opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         publicAddress: userToAddress
       } = await request.toWallet.getReceiveAddress({}) //  currencyCode ?
 
+      // Totle and other DEX's may not allow swapping to a different
+      // wallet (received coins must come to same wallet), throw not-enabled error
+      if (userFromAddress !== userToAddress) {
+        throw new SwapCurrencyError(swapInfo, fromToken, toToken)
+      }
+
       // Get the estimate from the server:
       const reply = await call({
         address: userFromAddress,
@@ -233,7 +239,6 @@ function makeTotleSwapPluginQuote (
 ): EdgeSwapPluginQuote {
   io.console.info(arguments)
   const { fromWallet } = request
-
   const swapTx = txs[txs.length - 1]
 
   const out: EdgeSwapPluginQuote = {


### PR DESCRIPTION
Throw "No enabled exchanges support DAI to BAT" error for Totle quotes that use different sending and receiving wallets. Totle only allows transactions with a destination wallet that is the same as the source wallet.