### PR TITLE
Update Totle plugin.

### DIFF
--- a/src/swap/totle.js
+++ b/src/swap/totle.js
@@ -145,12 +145,6 @@ export function makeTotlePlugin (opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         publicAddress: userToAddress
       } = await request.toWallet.getReceiveAddress({}) //  currencyCode ?
 
-      // Totle and other DEX's may not allow swapping to a different
-      // wallet (received coins must come to same wallet), throw not-enabled error
-      if (userFromAddress !== userToAddress) {
-        throw new SwapCurrencyError(swapInfo, fromToken, toToken)
-      }
-
       // Get the estimate from the server:
       const reply = await call({
         address: userFromAddress,
@@ -158,7 +152,8 @@ export function makeTotlePlugin (opts: EdgeCorePluginOptions): EdgeSwapPlugin {
           from: fromToken.address,
           to: toToken.address,
           [`${request.quoteFor}Amount`]: request.nativeAmount,
-          strictDestination: request.quoteFor === 'to'
+          strictDestination: request.quoteFor === 'to',
+          destinationAddress: userToAddress
         }
       })
       checkReply(reply, request)

--- a/src/swap/totle.js
+++ b/src/swap/totle.js
@@ -22,7 +22,7 @@ const swapInfo = {
 }
 
 const swapUri = 'https://api.totle.com/swap'
-const tokenUri = 'https://services.totlesystem.com/tokens'
+const tokenUri = 'https://api.totle.com/tokens'
 const expirationMs = 1000 * 60 * 20
 
 type QuoteInfo = {


### PR DESCRIPTION
1. Change tokens URI to updated link.
1. Add user's destination address to the API request to support sending result of swap to a different address.