### PR TITLE
Send refund address in API request in SideShift.ai plugin

### DIFF
--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -193,7 +193,8 @@ const createFetchSwapQuote = (api: SideshiftApi, affiliateId: string) =>
       type: 'fixed',
       quoteId: fixedQuote.id,
       affiliateId,
-      settleAddress
+      settleAddress,
+      refundAddress: depositAddress
     })
 
     const order = asOrder(
@@ -325,7 +326,8 @@ const asOrderRequest = asObject({
   type: asString,
   quoteId: asString,
   affiliateId: asString,
-  settleAddress: asString
+  settleAddress: asString,
+  refundAddress: asString
 })
 
 const asOrder = asEither(


### PR DESCRIPTION
This PR sends the refund address in the API request when an order is created through the SideShift.ai plugin. 

Currently users are required to manually enter their refund address on the SideShift.ai order page, which leads to many confused users and support tickets. With these changes, users will get refunded automatically if a refund is needed.