### PR TITLE
Ensure that all quotes expire in the future

### DIFF
--- a/src/swap-helpers.js
+++ b/src/swap-helpers.js
@@ -7,6 +7,18 @@ import {
   type EdgeTransaction
 } from 'edge-core-js/types'
 
+/**
+ * Ensures that a date is in the future by at least the given amount.
+ */
+export function ensureInFuture(
+  date?: Date,
+  marginSeconds: number = 30
+): Date | void {
+  if (date == null) return
+  const target = Date.now() + marginSeconds * 1000
+  return target < date.valueOf() ? date : new Date(target)
+}
+
 export function makeSwapPluginQuote(
   request: EdgeSwapRequest,
   fromNativeAmount: string,

--- a/src/swap/changenow.js
+++ b/src/swap/changenow.js
@@ -23,7 +23,7 @@ import {
   SwapCurrencyError
 } from 'edge-core-js/types'
 
-import { makeSwapPluginQuote } from '../swap-helpers.js'
+import { ensureInFuture, makeSwapPluginQuote } from '../swap-helpers.js'
 
 const pluginId = 'changenow'
 const swapInfo: EdgeSwapInfo = {
@@ -295,7 +295,7 @@ export function makeChangeNowPlugin(
                 toAddress,
                 pluginId,
                 false,
-                sendReply.validUntil,
+                ensureInFuture(sendReply.validUntil),
                 sendReply.id
               )
             }

--- a/src/swap/faast.js
+++ b/src/swap/faast.js
@@ -17,7 +17,7 @@ import {
   SwapPermissionError
 } from 'edge-core-js/types'
 
-import { makeSwapPluginQuote } from '../swap-helpers.js'
+import { ensureInFuture, makeSwapPluginQuote } from '../swap-helpers.js'
 
 const INVALID_CURRENCY_CODES = []
 
@@ -366,7 +366,7 @@ export function makeFaastPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         toAddressData.standardized,
         'faast',
         false,
-        new Date(quoteData.price_locked_until),
+        ensureInFuture(new Date(quoteData.price_locked_until)),
         quoteData.swap_id
       )
     }

--- a/src/swap/shapeshift.js
+++ b/src/swap/shapeshift.js
@@ -19,7 +19,7 @@ import {
   SwapPermissionError
 } from 'edge-core-js/types'
 
-import { makeSwapPluginQuote } from '../swap-helpers.js'
+import { ensureInFuture, makeSwapPluginQuote } from '../swap-helpers.js'
 
 const pluginId = 'shapeshift'
 const swapInfo: EdgeSwapInfo = {
@@ -299,7 +299,7 @@ export function makeShapeshiftPlugin(
         toAddress,
         'shapeshift',
         false,
-        new Date(exchangeData.expiration * 1000),
+        ensureInFuture(new Date(exchangeData.expiration * 1000)),
         exchangeData.orderId
       )
     }

--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -18,7 +18,7 @@ import {
   type EdgeSwapRequest
 } from 'edge-core-js/types'
 
-import { makeSwapPluginQuote } from '../swap-helpers.js'
+import { ensureInFuture, makeSwapPluginQuote } from '../swap-helpers.js'
 
 // Invalid currency codes should *not* have transcribed codes
 // because currency codes with transcribed versions are NOT invalid
@@ -257,7 +257,7 @@ const createFetchSwapQuote = (api: SideshiftApi, affiliateId: string) =>
       settleAddress,
       pluginId,
       isEstimate,
-      new Date(order.expiresAtISO),
+      ensureInFuture(new Date(order.expiresAtISO)),
       order.id
     )
   }


### PR DESCRIPTION
Many plugins use the pattern `new Date(Date.now() + expirationMs)`, which is obviously in the future. Other plugins use a date provided by the server, and they may need an adjustment if the phone's clock is wrong.