### PR TITLE
Disable FTM trading

### DIFF
--- a/src/swap/changelly.js
+++ b/src/swap/changelly.js
@@ -20,7 +20,9 @@ import utf8Codec from 'utf8'
 
 import { makeSwapPluginQuote } from '../swap-helpers.js'
 
-const INVALID_CURRENCY_CODES = {}
+const INVALID_CURRENCY_CODES = {
+  FTM: true
+}
 
 // Invalid currency codes should *not* have transcribed codes
 // because currency codes with transcribed versions are NOT invalid

--- a/src/swap/foxExchange.js
+++ b/src/swap/foxExchange.js
@@ -62,6 +62,10 @@ type OrderInfo = {
   frontendTimeout: number
 }
 
+const INVALID_CURRENCY_CODES = {
+  FTM: true
+}
+
 const dontUseLegacy = {
   DGB: true,
   LTC: true,
@@ -141,6 +145,17 @@ export function makeFoxExchangePlugin(
         }
 
         return json.data
+      }
+
+      if (
+        INVALID_CURRENCY_CODES[request.fromCurrencyCode] ||
+        INVALID_CURRENCY_CODES[request.toCurrencyCode]
+      ) {
+        throw new SwapCurrencyError(
+          swapInfo,
+          request.fromCurrencyCode,
+          request.toCurrencyCode
+        )
       }
 
       try {

--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -26,6 +26,9 @@ const CURRENCY_CODE_TRANSCRIPTION = {
   // Edge currencyCode: exchangeCurrencyCode
   USDT: 'usdtErc20'
 }
+const INVALID_CURRENCY_CODES = {
+  FTM: true
+}
 const SIDESHIFT_BASE_URL = 'https://sideshift.ai/api/v1'
 const pluginId = 'sideshift'
 const swapInfo: EdgeSwapInfo = {
@@ -128,6 +131,17 @@ const createFetchSwapQuote = (api: SideshiftApi, affiliateId: string) =>
   async function fetchSwapQuote(
     request: EdgeSwapRequest
   ): Promise<EdgeSwapQuote> {
+    if (
+      INVALID_CURRENCY_CODES[request.fromCurrencyCode] ||
+      INVALID_CURRENCY_CODES[request.toCurrencyCode]
+    ) {
+      throw new SwapCurrencyError(
+        swapInfo,
+        request.fromCurrencyCode,
+        request.toCurrencyCode
+      )
+    }
+
     const [depositAddress, settleAddress] = await Promise.all([
       getAddress(request.fromWallet, request.fromCurrencyCode),
       getAddress(request.toWallet, request.toCurrencyCode)

--- a/src/swap/switchain.js
+++ b/src/swap/switchain.js
@@ -68,6 +68,10 @@ type SwitchainOrderCreationBody = {
   promotionCode?: string
 }
 
+const INVALID_CURRENCY_CODES = {
+  FTM: true
+}
+
 const dontUseLegacy = {
   DGB: true,
   LTC: true
@@ -174,6 +178,13 @@ export function makeSwitchainPlugin(
       } = request
       let { fromCurrencyCode } = request
       const { promoCode } = opts
+
+      if (
+        INVALID_CURRENCY_CODES[fromCurrencyCode] ||
+        INVALID_CURRENCY_CODES[toCurrencyCode]
+      ) {
+        throw new SwapCurrencyError(swapInfo, fromCurrencyCode, toCurrencyCode)
+      }
 
       if (toCurrencyCode === fromCurrencyCode) {
         throw new SwapCurrencyError(swapInfo, fromCurrencyCode, toCurrencyCode)


### PR DESCRIPTION
This is a temporary measure to prevent users from trading FTM until exchange plugins can identify which mainnet chain they support. Among the active plugins, Changenow already has this in place and Godex is already upgraded to include mainnet in requests so no changes were necessary to their functionality.