### PR TITLE
Sideshift: include destinationTag in XRP tx

### DIFF
--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -1,6 +1,13 @@
 // @flow
 
-import { asBoolean, asEither, asObject, asOptional, asString } from 'cleaners'
+import {
+  asBoolean,
+  asEither,
+  asNumber,
+  asObject,
+  asOptional,
+  asString
+} from 'cleaners'
 import {
   type EdgeCorePluginOptions,
   type EdgeCurrencyWallet,
@@ -235,13 +242,17 @@ const createFetchSwapQuote = (api: SideshiftApi, affiliateId: string) =>
 
     const isEstimate = false
 
+    const destinationTag = order.depositAddress.destinationTag
+      ? order.depositAddress.destinationTag.toString()
+      : undefined
+
     const spendInfo: EdgeSpendInfo = {
       currencyCode: request.fromCurrencyCode,
       spendTargets: [
         {
           nativeAmount: spendInfoAmount,
           publicAddress: order.depositAddress.address,
-          uniqueIdentifier: order.depositAddress.memo
+          uniqueIdentifier: order.depositAddress.memo ?? destinationTag
         }
       ],
       networkFeeOption:
@@ -347,7 +358,8 @@ const asOrder = asEither(
     expiresAtISO: asString,
     depositAddress: asObject({
       address: asString,
-      memo: asOptional(asString)
+      memo: asOptional(asString),
+      destinationTag: asOptional(asNumber)
     }),
     id: asString,
     orderId: asString,

--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -242,9 +242,10 @@ const createFetchSwapQuote = (api: SideshiftApi, affiliateId: string) =>
 
     const isEstimate = false
 
-    const destinationTag = order.depositAddress.destinationTag
-      ? order.depositAddress.destinationTag.toString()
-      : undefined
+    const destinationTag =
+      order.depositAddress.destinationTag != null
+        ? `${order.depositAddress.destinationTag}`
+        : undefined
 
     const spendInfo: EdgeSpendInfo = {
       currencyCode: request.fromCurrencyCode,


### PR DESCRIPTION
At the moment XRP transactions sent to SideShift.ai do not include the `destinationTag` returned by the SideShift API, therefore they are rejected by the XRP network.

This PR appends the `destinationTag` to the XRP transactions, so they will be processed successfully.