### PR TITLE
Add lowerCase handling to getCodes

### DIFF
--- a/src/swap-helpers.js
+++ b/src/swap-helpers.js
@@ -66,12 +66,19 @@ export function makeSwapPluginQuote(
   return out
 }
 
-const getCodes = (request: EdgeSwapRequest) => ({
-  fromMainnetCode: request.fromWallet.currencyInfo.currencyCode,
-  toMainnetCode: request.toWallet.currencyInfo.currencyCode,
-  fromCurrencyCode: request.fromCurrencyCode,
-  toCurrencyCode: request.toCurrencyCode
-})
+const getCodes = (request: EdgeSwapRequest, toLowerCase: boolean) => {
+  const res = {
+    fromMainnetCode: request.fromWallet.currencyInfo.currencyCode,
+    toMainnetCode: request.toWallet.currencyInfo.currencyCode,
+    fromCurrencyCode: request.fromCurrencyCode,
+    toCurrencyCode: request.toCurrencyCode
+  }
+  if (toLowerCase)
+    Object.keys(res).forEach(key => {
+      res[key] = res[key].toLowerCase()
+    })
+  return res
+}
 
 export type InvalidCurrencyCodes = {
   from: { [code: string]: 'allCodes' | 'allTokens' | string[] },
@@ -91,7 +98,7 @@ export function checkInvalidCodes(
     toMainnetCode,
     fromCurrencyCode,
     toCurrencyCode
-  } = getCodes(request)
+  } = getCodes(request, false)
 
   function check(direction: string, main: string, token: string): boolean {
     switch (invalidCodes[direction][main]) {
@@ -128,7 +135,8 @@ export type CurrencyCodeTranscriptions = {
  */
 export function safeCurrencyCodes(
   transcriptionMap: CurrencyCodeTranscriptions,
-  request: EdgeSwapRequest
+  request: EdgeSwapRequest,
+  toLowerCase: boolean = false
 ): {
   safeFromCurrencyCode: string,
   safeToCurrencyCode: string
@@ -138,7 +146,7 @@ export function safeCurrencyCodes(
     toMainnetCode,
     fromCurrencyCode,
     toCurrencyCode
-  } = getCodes(request)
+  } = getCodes(request, toLowerCase)
 
   const out = {
     safeFromCurrencyCode: fromCurrencyCode,

--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -66,6 +66,8 @@ const swapInfo: EdgeSwapInfo = {
 }
 const ORDER_STATUS_URL = 'https://sideshift.ai/orders/'
 
+const LOWER_CASE_CODES = true
+
 async function getAddress(
   wallet: EdgeCurrencyWallet,
   currencyCode: string
@@ -155,7 +157,8 @@ const createFetchSwapQuote = (api: SideshiftApi, affiliateId: string) =>
 
     const { safeFromCurrencyCode, safeToCurrencyCode } = safeCurrencyCodes(
       CURRENCY_CODE_TRANSCRIPTION,
-      request
+      request,
+      LOWER_CASE_CODES
     )
 
     const rate = asRate(


### PR DESCRIPTION
Some partners, like Shapeshift and ChangeNow's v2 API, require lowercase codes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201573553283069