### PR TITLE
Transcribe AVAX in SideShift plugin

### DIFF
--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -43,6 +43,9 @@ const CURRENCY_CODE_TRANSCRIPTION = {
   },
   MATIC: {
     MATIC: 'polygon'
+  },
+  AVAX: {
+    AVAX: 'avaxc'
   }
 }
 const INVALID_CURRENCY_CODES: InvalidCurrencyCodes = {


### PR DESCRIPTION
Transcribes the AVAX currency code in the SideShift.ai plugin so users are able to exchange AVAX using SideShift.ai.