### PR TITLE
Disable selling DGB to Godex

### DIFF
--- a/src/swap/godex.js
+++ b/src/swap/godex.js
@@ -63,7 +63,8 @@ const INVALID_CURRENCY_CODES: InvalidCurrencyCodes = {
     AVAX: 'allTokens',
     CELO: 'allTokens',
     FTM: 'allTokens',
-    MATIC: 'allCodes'
+    MATIC: 'allCodes',
+    DGB: 'allCodes'
   },
   to: {
     ETH: ['MATIC'],


### PR DESCRIPTION
Godex uses legacy addresses which can cause issues when a user attempts to send a max amount which is calculated assuming a segwit address.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1200755251532617