### PR TITLE
Fix which engine to call denomination methods from

### DIFF
--- a/src/swap/changelly.js
+++ b/src/swap/changelly.js
@@ -286,7 +286,7 @@ export function makeChangellyPlugin(
         sendReply.result.amountExpectedFrom,
         request.fromCurrencyCode
       )
-      const amountExpectedToTo = await request.fromWallet.denominationToNative(
+      const amountExpectedToTo = await request.toWallet.denominationToNative(
         sendReply.result.amountExpectedTo,
         request.toCurrencyCode
       )

--- a/src/swap/exolix.js
+++ b/src/swap/exolix.js
@@ -189,7 +189,7 @@ export function makeExolixPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         request.fromCurrencyCode
       )
 
-      const toNativeAmount = await request.fromWallet.denominationToNative(
+      const toNativeAmount = await request.toWallet.denominationToNative(
         quoteInfo.amount_to.toString(),
         request.toCurrencyCode
       )

--- a/src/swap/sideshift.js
+++ b/src/swap/sideshift.js
@@ -255,7 +255,7 @@ const createFetchSwapQuote = (api: SideshiftApi, affiliateId: string) =>
       request.fromCurrencyCode
     )
 
-    const amountExpectedToNative = await request.fromWallet.denominationToNative(
+    const amountExpectedToNative = await request.toWallet.denominationToNative(
       order.settleAmount,
       request.toCurrencyCode
     )


### PR DESCRIPTION
These wallet methods used to search over all available plugins for a currency code match. The latest core update limits the currency code search to their respective plugin so we need to be more careful about which wallet we call these methods from.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201910043204702