### PR TITLE
Don't allow transfers if the currency code doesn't match

### DIFF
--- a/src/swap/transfer.js
+++ b/src/swap/transfer.js
@@ -35,7 +35,8 @@ export function makeTransferPlugin(
     ): Promise<EdgeSwapQuote> {
       if (
         request.fromWallet.currencyInfo.pluginId !==
-        request.toWallet.currencyInfo.pluginId
+          request.toWallet.currencyInfo.pluginId ||
+        request.fromCurrencyCode !== request.toCurrencyCode
       ) {
         throw new SwapCurrencyError(
           swapInfo,


### PR DESCRIPTION
This was accidentally replaced by the pluginId check when BSC went live instead of added to