### PR TITLE
Restrict matic swaps on exolix

### DIFF
--- a/src/swap/exolix.ts
+++ b/src/swap/exolix.ts
@@ -34,9 +34,13 @@ const asInitOptions = asObject({
 
 const INVALID_CURRENCY_CODES: InvalidCurrencyCodes = {
   from: {
+    ethereum: ['MATIC'],
+    polygon: 'allCodes',
     binancesmartchain: 'allCodes'
   },
   to: {
+    ethereum: ['MATIC'],
+    polygon: 'allCodes',
     binancesmartchain: 'allCodes',
     zcash: ['ZEC']
   }


### PR DESCRIPTION
Exolix is incorrectly assuming matic bep20 as the token and user is sending or wanting