### PR TITLE
Remove extra slash from thorswap URL

### DIFF
--- a/src/swap/defi/thorchainDa.ts
+++ b/src/swap/defi/thorchainDa.ts
@@ -240,7 +240,7 @@ export function makeThorchainDaPlugin(
       const sourceTokenContractAddress = fromTokenId?.replace('-0x', '0x')
 
       const queryParams = makeQueryParams(quoteParams)
-      const uri = `/tokens/quote?${queryParams}`
+      const uri = `tokens/quote?${queryParams}`
 
       log.warn(uri)
 


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203598419533700