### PR TITLE
Godex: Flip minimum amount and network checks

### DIFF
--- a/src/swap/godex.ts
+++ b/src/swap/godex.ts
@@ -195,21 +195,8 @@ export function makeGodexPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
     })
     const reply = asApiInfo(response)
 
-    // Check the networks. Networks aren't present for disabled assets.
-    if (
-      reply.networks_from?.find(
-        network => network.network === fromMainnetCode
-      ) == null ||
-      reply.networks_to?.find(network => network.network === toMainnetCode) ==
-        null
-    ) {
-      throw new SwapCurrencyError(
-        swapInfo,
-        request.fromCurrencyCode,
-        request.toCurrencyCode
-      )
-    }
-
+    // The info/info-revert endpoints don't accept the coin_from/coin_to params so the
+    // min_amount returned could be for a different network than the user is requesting.
     // Check the minimum:
     const nativeMin = reverseQuote
       ? await request.toWallet.denominationToNative(
@@ -226,6 +213,21 @@ export function makeGodexPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         swapInfo,
         nativeMin,
         reverseQuote ? 'to' : 'from'
+      )
+    }
+
+    // Check the networks. Networks aren't present for disabled assets.
+    if (
+      reply.networks_from?.find(
+        network => network.network === fromMainnetCode
+      ) == null ||
+      reply.networks_to?.find(network => network.network === toMainnetCode) ==
+        null
+    ) {
+      throw new SwapCurrencyError(
+        swapInfo,
+        request.fromCurrencyCode,
+        request.toCurrencyCode
       )
     }
 


### PR DESCRIPTION
The response for requested swaps below the minimums does not include chain info so it was getting caught in the unsupported error flow. I pinged Godex for clarity on how to tell which networks the min_amount applied to since we don't get to specify that before receiving the minimum error.

As far as I can tell, it is possible the returned min_amount might be for a different network than the user requests but it's probably better to show that than completely unsupported.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203493677512989