### PR TITLE
Do not use LIFI gasLimit estimate for ethereum sends

### DIFF
--- a/src/swap/defi/lifi.ts
+++ b/src/swap/defi/lifi.ts
@@ -337,7 +337,12 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       ],
       networkFeeOption: 'custom',
       customNetworkFee: {
-        gasLimit: hexToDecimal(gasLimit),
+        // XXX Hack. Lifi doesn't properly estimate ethereum gas limits. Use our own
+        // gasLimit estimator
+        gasLimit:
+          fromWallet.currencyInfo.pluginId !== 'ethereum'
+            ? hexToDecimal(gasLimit)
+            : undefined,
         gasPrice: gasPriceGwei
       },
       swapData: {


### PR DESCRIPTION
Estimate gas ourselves in the eth plugin as Lifi estimates too low of a gaslimit

### CHANGELOG

none

### Dependencies

none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204220766101352