### PR TITLE
Add default zkSync "ZKSYNC" mainnet code

### DIFF
--- a/src/swap-helpers.ts
+++ b/src/swap-helpers.ts
@@ -302,7 +302,8 @@ const defaultCurrencyCodeTranscriptionMap: CurrencyCodeTranscriptionMap = {
 }
 
 const defaultMainnetTranscriptionMap: MainnetPluginIdTranscriptionMap = {
-  optimism: 'OP' // mainnet code is ETH
+  optimism: 'OP', // mainnet code is ETH
+  zksync: 'ZKSYNC' // mainnet code is also ETH
 }
 
 /**


### PR DESCRIPTION
Some plugins don't support zkSync yet so we don't know what the 
mainnet would be called. 
This provides protection against a plugin from adding supporting and 
defaulting to the ETH mainnet code.

### CHANGELOG

- Changed: Transcribe zkSync mainnet code to ZKSYNC

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
