### PR TITLE
Use Lifi gasLimit estimates for eth + 40%

### DIFF
--- a/src/swap/defi/lifi.ts
+++ b/src/swap/defi/lifi.ts
@@ -1,3 +1,4 @@
+import { mul } from 'biggystring'
 import { asArray, asNumber, asObject, asOptional, asString } from 'cleaners'
 import {
   EdgeCorePluginOptions,
@@ -338,12 +339,11 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       ],
       networkFeeOption: 'custom',
       customNetworkFee: {
-        // XXX Hack. Lifi doesn't properly estimate ethereum gas limits. Use our own
-        // gasLimit estimator
+        // XXX Hack. Lifi doesn't properly estimate ethereum gas limits. Increase by 40%
         gasLimit:
           fromWallet.currencyInfo.pluginId !== 'ethereum'
             ? hexToDecimal(gasLimit)
-            : undefined,
+            : mul(hexToDecimal(gasLimit), '1.4'),
         gasPrice: gasPriceGwei
       },
       swapData: {


### PR DESCRIPTION
RPC nodes are now unable to estimate gasLimit and cause fallback to 300000 gas which is insufficient for Lifi contracts.

### CHANGELOG

<!-- Replace line with entries for the CHANGELOG if any --> none

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204422412177286