### PR TITLE
Explicitly disable zksync for swapuz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed: Fix zkSync mainnet code transcription for LetsExchange.
+- Fixed: Disable zkSync explicitly for Swapuz.
 
 ## 0.19.1 (2023-04-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # edge-exchange-plugins
 
+## Unreleased
+
+- Fixed: Fix zkSync mainnet code transcription for LetsExchange.
+
 ## 0.19.1 (2023-04-27)
 
 - Fixed: Lifi gasLimit calculation for ETH

--- a/src/swap/letsexchange.ts
+++ b/src/swap/letsexchange.ts
@@ -84,6 +84,9 @@ const SPECIAL_MAINNET_CASES: { [pId: string]: { [cc: string]: string } } = {
   },
   optimism: {
     ETH: 'OPTIMISM'
+  },
+  zksync: {
+    ETH: 'ZKSYNC'
   }
 }
 

--- a/src/swap/swapuz.ts
+++ b/src/swap/swapuz.ts
@@ -51,7 +51,8 @@ const uri = 'https://api.swapuz.com/api/home/v1/'
 const INVALID_CURRENCY_CODES: InvalidCurrencyCodes = {
   from: {},
   to: {
-    zcash: ['ZEC']
+    zcash: ['ZEC'],
+    zksync: 'allCodes'
   }
 }
 


### PR DESCRIPTION
### CHANGELOG

- Fixed: Fix zkSync mainnet code transcription for LetsExchange.
- Fixed: Disable zkSync explicitly for Swapuz.

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204474155042560