### PR TITLE
Always use 40% gas limit increase for LI.FI

### DIFF
--- a/src/swap/defi/lifi.ts
+++ b/src/swap/defi/lifi.ts
@@ -340,10 +340,7 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       networkFeeOption: 'custom',
       customNetworkFee: {
         // XXX Hack. Lifi doesn't properly estimate ethereum gas limits. Increase by 40%
-        gasLimit:
-          fromWallet.currencyInfo.pluginId !== 'ethereum'
-            ? hexToDecimal(gasLimit)
-            : round(mul(hexToDecimal(gasLimit), '1.4'), 0),
+        gasLimit: round(mul(hexToDecimal(gasLimit), '1.4'), 0),
         gasPrice: gasPriceGwei
       },
       swapData: {


### PR DESCRIPTION
The LI.FI issue may be helped by this change, but no evidence to support that this completely fixes the problem.

### CHANGELOG

- Fixed: Increased gas limit by 40% for all chains for LI.FI

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204953687205427