### PR TITLE
Use the `value` from the LI.FI quote response data directly

### DIFF
--- a/src/swap/defi/lifi.ts
+++ b/src/swap/defi/lifi.ts
@@ -291,10 +291,10 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
 
     const quoteJson = await quoteResponse.json()
     const quote = asV1Quote(quoteJson)
-    const { estimate, includedSteps } = quote
+    const { estimate, includedSteps, transactionRequest } = quote
     const { approvalAddress, toAmountMin } = estimate
 
-    const { data, gasLimit, gasPrice } = quote.transactionRequest
+    const { data, gasLimit, gasPrice } = transactionRequest
     const gasPriceDecimal = hexToDecimal(gasPrice)
     const gasPriceGwei = div18(gasPriceDecimal, '1000000000')
     const providers = includedSteps.map(s => s.toolDetails.name)
@@ -333,7 +333,7 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       spendTargets: [
         {
           memo: data,
-          nativeAmount: nativeAmount,
+          nativeAmount: mul(transactionRequest.value, '1'),
           publicAddress: approvalAddress
         }
       ],


### PR DESCRIPTION
The mainnet value must be sent as it is calculated by the LI.FI API because it includes mainnet amount needed to pay for bridge fees within the smart contract.

### CHANGELOG

- Fixed: LI.FI on-chain transactions no longer revert due to missing bridge fees

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204953687205427