### PR TITLE
Remove use of legacy memos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - added: Login info to testconfig for testpartners.ts
 - changed: Change Lifi and Thorchain DA to use variable quotes
 - fixed: Memo handling by DEX plugins
+- fixed: Letsexchange orderUri
 
 ## 2.3.1 (2024-03-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - added: Login info to testconfig for testpartners.ts
 - changed: Change Lifi and Thorchain DA to use variable quotes
-- fixed: LiFi and Thorchain/DA memo handling
+- fixed: Memo handling by DEX plugins
 
 ## 2.3.1 (2024-03-29)
 

--- a/src/swap/central/letsexchange.ts
+++ b/src/swap/central/letsexchange.ts
@@ -42,7 +42,7 @@ const asInitOptions = asObject({
   affiliateId: asOptional(asString)
 })
 
-const orderUri = 'https://letsexchange.io/?exchangeId='
+const orderUri = 'https://letsexchange.io/?transactionId='
 const uri = 'https://api.letsexchange.io/api/v1/'
 
 const expirationMs = 1000 * 60

--- a/src/swap/defi/defiUtils.ts
+++ b/src/swap/defi/defiUtils.ts
@@ -96,7 +96,7 @@ export const getEvmApprovalData = async (params: {
       gasPrice: '20'
     }
   )
-  return approveTx.data != null ? approveTx.data.replace('0x', '') : undefined
+  return approveTx.data != null ? approveTx.data.replace(/^0x/, '') : undefined
 }
 
 export const getEvmTokenData = async (params: {

--- a/src/swap/defi/lifi.ts
+++ b/src/swap/defi/lifi.ts
@@ -353,11 +353,11 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       tokenId: request.fromTokenId,
       spendTargets: [
         {
-          memo: data,
           nativeAmount: fromNativeAmount,
           publicAddress: approvalAddress
         }
       ],
+      memos: [{ type: 'hex', value: data.replace(/^0x/, '') }],
       networkFeeOption: 'custom',
       customNetworkFee: {
         // XXX Hack. Lifi doesn't properly estimate ethereum gas limits. Increase by 40%

--- a/src/swap/defi/thorchain.ts
+++ b/src/swap/defi/thorchain.ts
@@ -566,7 +566,6 @@ export function makeThorchainPlugin(
           vaultAddress: thorAddress,
           memo
         })
-        memo = memo.replace('0x', '')
 
         // Token transactions send no ETH (or other EVM mainnet coin)
         ethNativeAmount = '0'
@@ -581,6 +580,7 @@ export function makeThorchainPlugin(
       } else {
         memo = Buffer.from(memo).toString('hex')
       }
+      memo = memo.replace(/^0x/, '')
     } else if (fromWallet.currencyInfo.pluginId === 'thorchainrune') {
       const makeTxParams: MakeTxParams = {
         type: 'MakeTxDeposit',
@@ -625,9 +625,12 @@ export function makeThorchainPlugin(
         expirationDate: new Date(Date.now() + EXPIRATION_MS)
       }
     } else {
+      // For UTXO chains, we send the memo as text which gets
+      // encoded by the plugins
       memoType = 'text'
-      // Cannot yet do tokens on non-EVM chains
+
       if (fromTokenId != null) {
+        // Cannot yet do tokens on utxo chains
         throw new SwapCurrencyError(swapInfo, request)
       }
     }

--- a/src/swap/defi/thorchainDa.ts
+++ b/src/swap/defi/thorchainDa.ts
@@ -341,7 +341,7 @@ export function makeThorchainDaPlugin(
     //   throw new SwapCurrencyError(swapInfo, request)
     // }
 
-    const memoType: EdgeMemo['type'] = 'hex'
+    let memoType: EdgeMemo['type'] = 'hex'
     let memo = calldata.tcMemo ?? calldata.memo ?? ''
 
     log.warn(memo)
@@ -396,8 +396,10 @@ export function makeThorchainDaPlugin(
       } else {
         memo = Buffer.from(memo).toString('hex')
       }
+      memo = memo.replace(/^0x/, '')
     } else {
       // Cannot yet do tokens on non-EVM chains
+      memoType = 'text'
       if (fromMainnetCode !== fromCurrencyCode) {
         throw new SwapCurrencyError(swapInfo, request)
       }
@@ -446,8 +448,7 @@ export function makeThorchainDaPlugin(
       assetAction: {
         assetActionType: 'swap'
       },
-      memos:
-        memo == null ? [] : [{ type: memoType, value: memo.replace('0x', '') }],
+      memos: memo == null ? undefined : [{ type: memoType, value: memo }],
       savedAction: {
         actionType: 'swap',
         swapInfo,

--- a/src/swap/defi/uni-v2-based/plugins/spookySwap.ts
+++ b/src/swap/defi/uni-v2-based/plugins/spookySwap.ts
@@ -112,7 +112,6 @@ export function makeSpookySwapPlugin(
         tokenId: request.fromTokenId,
         spendTargets: [
           {
-            memo: swapTx.data,
             nativeAmount:
               swapTxs.length === 2 && i === 0
                 ? '0' // approval transactions don't have a value
@@ -120,6 +119,10 @@ export function makeSpookySwapPlugin(
             publicAddress: swapTx.to
           }
         ],
+        memos:
+          swapTx.data != null
+            ? [{ type: 'hex', value: swapTx.data.replace(/^0x/, '') }]
+            : undefined,
         customNetworkFee: {
           gasPrice:
             swapTx.gasPrice != null

--- a/src/swap/defi/uni-v2-based/plugins/tombSwap.ts
+++ b/src/swap/defi/uni-v2-based/plugins/tombSwap.ts
@@ -112,7 +112,6 @@ export function makeTombSwapPlugin(
         tokenId: request.fromTokenId,
         spendTargets: [
           {
-            memo: swapTx.data,
             nativeAmount:
               swapTxs.length === 2 && i === 0
                 ? '0' // approval transactions don't have a value
@@ -120,6 +119,10 @@ export function makeTombSwapPlugin(
             publicAddress: swapTx.to
           }
         ],
+        memos:
+          swapTx.data != null
+            ? [{ type: 'hex', value: swapTx.data.replace(/^0x/, '') }]
+            : undefined,
         customNetworkFee: {
           gasPrice:
             swapTx.gasPrice != null

--- a/src/swap/defi/uni-v2-based/plugins/velodrome.ts
+++ b/src/swap/defi/uni-v2-based/plugins/velodrome.ts
@@ -125,7 +125,6 @@ export function makeVelodromePlugin(
         tokenId: request.fromTokenId,
         spendTargets: [
           {
-            memo: swapTx.data,
             nativeAmount:
               swapTxs.length === 2 && i === 0
                 ? '0' // approval transactions don't have a value
@@ -133,6 +132,10 @@ export function makeVelodromePlugin(
             publicAddress: swapTx.to
           }
         ],
+        memos:
+          swapTx.data != null
+            ? [{ type: 'hex', value: swapTx.data.replace(/^0x/, '') }]
+            : undefined,
         customNetworkFee: {
           gasPrice:
             swapTx.gasPrice != null


### PR DESCRIPTION
Latest edge-currency-accountbased removed use so we must use the new `memos` field or risk having memos dropped

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207003131677435