### PR TITLE
Leverage either amount fields from thorchain swap API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Thorchain swap error caused by failing cleaner
+
 ## 2.7.3 (2024-07-23)
 
 - changed: Cap Exolix to 70k USD swaps


### PR DESCRIPTION
I don't have a clear understanding of the difference between streaming amounts and non-streaming amounts, but this fixes the cleaner error.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207898557159096