### PR TITLE
Add secret header to SideShift

### DIFF
--- a/src/swap/central/sideshift.ts
+++ b/src/swap/central/sideshift.ts
@@ -152,7 +152,8 @@ interface CreateSideshiftApiResponse {
 
 const createSideshiftApi = (
   baseUrl: string,
-  fetchCors: EdgeFetchFunction
+  fetchCors: EdgeFetchFunction,
+  privateKey?: string
 ): CreateSideshiftApiResponse => {
   async function request<R>(
     method: 'GET' | 'POST',
@@ -161,12 +162,17 @@ const createSideshiftApi = (
   ): Promise<R> {
     const url = `${baseUrl}${path}`
 
+    const headers = {
+      'x-sideshift-secret': privateKey
+    }
+
     const reply = await (method === 'GET'
-      ? fetchCors(url)
+      ? fetchCors(url, { headers })
       : fetchCors(url, {
           method,
           headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            ...headers
           },
           body: JSON.stringify(body)
         }))
@@ -352,7 +358,7 @@ export function makeSideshiftPlugin(
   opts: EdgeCorePluginOptions
 ): EdgeSwapPlugin {
   const { io, initOptions } = opts
-  const api = createSideshiftApi(SIDESHIFT_BASE_URL, io.fetchCors ?? io.fetch)
+  const api = createSideshiftApi(SIDESHIFT_BASE_URL, io.fetchCors ?? io.fetch, initOptions.privateKey)
   const fetchSwapQuote = createFetchSwapQuote(api, initOptions.affiliateId)
 
   return {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

Add the SideShift.ai private key to the API requests as `x-sideshif-secret` header. See https://github.com/EdgeApp/edge-react-gui/pull/5369


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208828332101201