### PR TITLE
Fix incorrect date for 0xGasless EdgeTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Incorrect date timestamp for 0xGasless transactions.
+
 ## 2.16.0 (2024-12-16)
 
 - added: (Rango) Add Solana support

--- a/src/swap/defi/0x/0xGasless.ts
+++ b/src/swap/defi/0x/0xGasless.ts
@@ -207,7 +207,7 @@ export const make0xGaslessPlugin: EdgeCorePluginFactory = opts => {
             assetAction,
             blockHeight: 0,
             currencyCode: fromCurrencyCode,
-            date: Date.now(),
+            date: Date.now() / 1000,
             isSend: true,
             memos: [],
             nativeAmount: swapNativeAmount,


### PR DESCRIPTION
The dates for EdgeTransaction types are in unix seconds, not unix
milliseconds.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208648365972985