### PR TITLE
Fix lifi tx amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: 0 amount in pending transactions from LI.FI swaps from tokens
+
 ## 2.21.0 (2025-04-16)
 
 - added: Add PIVX support to ChangeNow, Exolix, Godex, and LetsExchange centralized exchanges

--- a/src/swap/defi/lifi.ts
+++ b/src/swap/defi/lifi.ts
@@ -350,7 +350,7 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
     const providers = includedSteps.map(s => s.toolDetails.name)
     const providersStr = providers.join(' -> ')
     const metadataNotes = `DEX Providers: ${providersStr}`
-    const { approvalAddress, toAmount, toAmountMin } = estimate
+    const { approvalAddress, toAmount, toAmountMin, fromAmount } = estimate
 
     let preTx: EdgeTransaction | undefined
     let spendInfo: EdgeSpendInfo
@@ -363,12 +363,11 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         }
         const { data } = asTransactionRequestSolana(transactionRequestRaw)
 
-        const fromNativeAmount = estimate.fromAmount
         spendInfo = {
           tokenId: request.fromTokenId,
           spendTargets: [
             {
-              nativeAmount: fromNativeAmount,
+              nativeAmount: fromAmount,
               publicAddress: publicAddress
             }
           ],
@@ -390,7 +389,7 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
             fromAsset: {
               pluginId: fromWallet.currencyInfo.pluginId,
               tokenId: fromTokenId,
-              nativeAmount: fromNativeAmount
+              nativeAmount: fromAmount
             },
             payoutAddress: toAddress,
             payoutWalletId: toWallet.id,
@@ -413,7 +412,7 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
             nativeAmount
           })
 
-          const spendInfo: EdgeSpendInfo = {
+          const preTxSpendInfo: EdgeSpendInfo = {
             // Token approvals only spend the parent currency
             tokenId: null,
             spendTargets: [
@@ -444,15 +443,14 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
               contractAddress: approvalAddress
             }
           }
-          preTx = await request.fromWallet.makeSpend(spendInfo)
+          preTx = await request.fromWallet.makeSpend(preTxSpendInfo)
         }
 
-        const fromNativeAmount = mul(transactionRequest.value, '1')
         spendInfo = {
           tokenId: request.fromTokenId,
           spendTargets: [
             {
-              nativeAmount: fromNativeAmount,
+              nativeAmount: fromAmount,
               publicAddress: approvalAddress
             }
           ],
@@ -478,7 +476,7 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
             fromAsset: {
               pluginId: fromWallet.currencyInfo.pluginId,
               tokenId: fromTokenId,
-              nativeAmount: fromNativeAmount
+              nativeAmount: fromAmount
             },
             payoutAddress: toAddress,
             payoutWalletId: toWallet.id,


### PR DESCRIPTION
The `fromNativeAmount` was previously referencing a value from the V1 quote that is `0x0` when swapping from a token.

Reference PR that last changed this: https://github.com/EdgeApp/edge-exchange-plugins/pull/281

Issue described from the prior change https://app.asana.com/1/9976422036640/project/1200382638405084/task/1204940534353339 was tested, a swap from POL -> USDC(Avalanche) works

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209776297342859