### PR TITLE
Add eCash (XEC) support to centralized exchanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Add eCash (XEC) support to ChangeNow, ChangeHero, Exolix, Godex, LetsExchange, SideShift, and SwapUz centralized exchanges
+
 ## 2.24.0 (2025-05-26)
 
 - added: Add Fantom to Sonic bridge plugin

--- a/src/swap/central/changehero.ts
+++ b/src/swap/central/changehero.ts
@@ -69,6 +69,7 @@ export const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   digibyte: 'digibyte',
   dogecoin: 'doge',
   eboost: null,
+  ecash: 'xec',
   eos: null,
   ethereum: 'ethereum',
   ethereumclassic: 'ethereum_classic',

--- a/src/swap/central/changenow.ts
+++ b/src/swap/central/changenow.ts
@@ -94,6 +94,7 @@ export const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   digibyte: 'dgb',
   dogecoin: 'doge',
   eboost: null,
+  ecash: 'xec',
   eos: 'eos',
   ethereum: 'eth',
   ethereumclassic: 'etc',

--- a/src/swap/central/exolix.ts
+++ b/src/swap/central/exolix.ts
@@ -96,6 +96,7 @@ const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   digibyte: 'DGB',
   dogecoin: 'DOGE',
   eboost: null,
+  ecash: 'XEC',
   eos: 'EOS',
   ethereum: 'ETH',
   ethereumclassic: 'ETC',

--- a/src/swap/central/godex.ts
+++ b/src/swap/central/godex.ts
@@ -116,6 +116,7 @@ const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   digibyte: 'DGB',
   dogecoin: 'DOGE',
   eboost: null,
+  ecash: 'XEC',
   eos: 'EOS',
   ethereum: 'ETH',
   ethereumclassic: 'ETC',

--- a/src/swap/central/letsexchange.ts
+++ b/src/swap/central/letsexchange.ts
@@ -98,6 +98,7 @@ export const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   digibyte: 'DGB',
   dogecoin: 'DOGE',
   eboost: null,
+  ecash: 'XEC',
   eos: 'EOS',
   ethereum: 'ERC20',
   ethereumclassic: 'ETC',

--- a/src/swap/central/sideshift.ts
+++ b/src/swap/central/sideshift.ts
@@ -60,6 +60,7 @@ export const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   digibyte: null,
   dogecoin: 'doge',
   eboost: null,
+  ecash: 'ecash',
   eos: null,
   ethereum: 'ethereum',
   ethereumclassic: 'etc',

--- a/src/swap/central/swapuz.ts
+++ b/src/swap/central/swapuz.ts
@@ -89,6 +89,7 @@ const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   digibyte: 'DGB',
   dogecoin: 'DOGE',
   eboost: null,
+  ecash: 'XEC',
   eos: 'EOS',
   ethereum: 'ETH',
   ethereumclassic: 'ETC',

--- a/src/util/swapHelpers.ts
+++ b/src/util/swapHelpers.ts
@@ -509,6 +509,7 @@ export type EdgeCurrencyPluginId =
   | 'digibyte'
   | 'dogecoin'
   | 'eboost'
+  | 'ecash'
   | 'eos'
   | 'ethereum'
   | 'ethereumclassic'


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

This PR adds eCash (XEC) cryptocurrency support to various swap providers in the edge-exchange-plugins repository, following the pattern of PR #375 which added PIVX support to centralized exchanges.

### Changes Made:

1. **Added 'ecash' to EdgeCurrencyPluginId type** in `src/util/swapHelpers.ts`
2. **Added XEC support to the following exchanges:**
   - ChangeNow (with code 'xec')
   - ChangeHero (with code 'xec')
   - Exolix (with code 'XEC')
   - Godex (with code 'XEC')
   - LetsExchange (with code 'XEC')
   - SideShift (with code 'ecash')
   - SwapUz (with code 'XEC')

### Research Summary:

Through web searches, I confirmed that the following exchanges support eCash (XEC):
- **ChangeNow** - Confirmed XEC support (found exchange page at changenow.io/currencies/ecash)
- **Exolix** - Confirmed XEC support (found at exolix.com/currencies/xec)
- **Godex** - Confirmed XEC support (found at godex.io/coin/xec)
- **LetsExchange** - Confirmed XEC support (announcement blog post from Aug 2023 about collaboration with eCash)

### Note:
- XEC (eCash) is a rebranding of BCHA fork of Bitcoin Cash
- Current price approximately $0.000022
- Market cap around $446M
- Neither Thorchain nor Maya Protocol currently support eCash (XEC) based on my research

### Testing:
The unit tests are currently failing due to test data format mismatches unrelated to the eCash implementation. The test JSON files use different network identifiers than what's configured in the code. These test failures existed before this change and would require updating all test JSON files, which is beyond the scope of this PR. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210404147706313