### PR TITLE
Ignore recommended fee rate for EVM currencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (Thorchain/Maya) Ignore recommended EVM gas price
+
 ## 2.25.1 (2025-06-06)
 
 - changed: Label Fantom/Sonic Upgrade plugin as a DEX

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -748,18 +748,12 @@ export function makeThorchainBasedPlugin(
             customNetworkFee = { satPerByte: recommendedGasRate }
           }
           break
-        case 'ethereum':
-        case 'ethereum-pos':
-        case 'optimism':
-        case 'arbitrum':
-        case 'base':
-        case 'avalanche':
-        case 'binancesmartchain':
-        case 'fantom':
-          if (gasRateUnits === 'gwei') {
-            customNetworkFee = { gasPrice: recommendedGasRate }
-          }
-          break
+        // The recommendation for EVM is bad
+        // case 'arbitrum':
+        // case 'avalanche':
+        // case 'base':
+        // case 'binancesmartchain':
+        // case 'ethereum':
         default:
           log.warn(`Gas rate units not available for ${pluginId}`)
       }


### PR DESCRIPTION
The rate is bad and isn't close to etherscan low/normal/high and what we see from nodes. For example, when the baseFee was spiking around 11-13, the /quote response was recommending 3 or 4.

The plugin list changed because they either weren't supported or were nonsense values.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210456727737137