### PR TITLE
Use pendingTxs in multi-tx swaps

### DIFF
--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -9,6 +9,7 @@ import {
 import {
   EdgeAssetAction,
   EdgeCurrencyWallet,
+  EdgeTransaction,
   EdgeTxActionSwap
 } from 'edge-core-js'
 
@@ -46,6 +47,8 @@ export type MakeTxParams =
       toTokenId: string | null
       toNativeAmount: string
 
+      pendingTxs?: EdgeTransaction[]
+
       /**
        * UNIX time (seconds) to expire the DEX swap if it hasn't executed
        */
@@ -61,6 +64,7 @@ export type MakeTxParams =
       memo: string
       assetAction: EdgeAssetAction
       savedAction: EdgeTxActionSwap
+      pendingTxs?: EdgeTransaction[]
     }
 
 export const asRatesResponse = asObject({

--- a/src/util/swapHelpers.ts
+++ b/src/util/swapHelpers.ts
@@ -76,11 +76,15 @@ export async function makeSwapPluginQuote(
   let tx: EdgeTransaction
   if ('spendInfo' in order) {
     const { spendInfo } = order
-    tx = await fromWallet.makeSpend(spendInfo)
+    const spend =
+      preTx != null ? { ...spendInfo, pendingTxs: [preTx] } : spendInfo
+    tx = await fromWallet.makeSpend(spend)
   } else {
     const { makeTxParams } = order
     const { assetAction, savedAction } = makeTxParams
-    tx = await fromWallet.otherMethods.makeTx(makeTxParams)
+    const params =
+      preTx != null ? { ...makeTxParams, pendingTxs: [preTx] } : makeTxParams
+    tx = await fromWallet.otherMethods.makeTx(params)
     if (tx.tokenId == null) {
       tx.tokenId = request.fromTokenId
     }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

- chain swap transactions by passing previous transactions to `makeSpend`
- allow `MakeTxParams` to include `pendingTxs`
- document every `makeSpend` invocation and whether it uses `pendingTxs`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210515530676589