### PR TITLE
Remove HyperEVM from Exolix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Remove HyperEVM mapping to HYPE on HyperLiquid on Exolix.
+
 ## 2.29.0 (2025-07-21)
 
 - added: Support for hyperevm to ChangeHero, Exolix, LetsExchange.

--- a/src/swap/central/exolix.ts
+++ b/src/swap/central/exolix.ts
@@ -122,7 +122,7 @@ const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = {
   fio: null,
   groestlcoin: null,
   hedera: 'HBAR',
-  hyperevm: 'HYPE',
+  hyperevm: null,
   liberland: null,
   litecoin: 'LTC',
   monero: 'XMR',


### PR DESCRIPTION
Exolix doesn't support HyperEVM. It was mistakenly confused for HyperLiquid main network.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210882648647106