### PR TITLE
FTM->S - throw typed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Fantom/Sonic Upgrade: throw `SwapAddressError` when from/to wallet addresses differ so the GUI can auto-select or split a FTM wallet
+
 ## 2.31.0 (2025-08-04)
 
 - changed: Configure ESBuild to assume es2015 support

--- a/src/swap/defi/fantomSonicUpgrade.ts
+++ b/src/swap/defi/fantomSonicUpgrade.ts
@@ -7,6 +7,7 @@ import {
   EdgeSwapQuote,
   EdgeSwapRequest,
   SwapAboveLimitError,
+  SwapAddressError,
   SwapBelowLimitError,
   SwapCurrencyError
 } from 'edge-core-js/types'
@@ -56,7 +57,7 @@ export function makeFantomSonicUpgradePlugin(
     const toAddress = await getAddress(request.toWallet)
 
     if (fromAddress !== toAddress) {
-      throw new Error('From and to addresses must be the same')
+      throw new SwapAddressError(swapInfo, { reason: 'mustMatch' })
     }
 
     const providers = rpcs.map(rpc => new ethers.providers.JsonRpcProvider(rpc))


### PR DESCRIPTION
Throw `SwapNeedsSplitError` when from/to wallet addresses differ so the GUI can auto-select or split a FTM wallet

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211060733374977