### PR TITLE
feat(lifi): add SUI blockchain support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: (LI.FI) Add SUI blockchain support for swaps via Aftermath and Bluefin7k DEXs
+
 ## 2.33.0 (2025-09-09)
 
 - added: Add Bridgeless plugin

--- a/src/util/swapHelpers.ts
+++ b/src/util/swapHelpers.ts
@@ -85,11 +85,17 @@ export async function makeSwapPluginQuote(
     // Handle the new MakeTx type for SUI
     if (makeTxParams.type === 'MakeTx') {
       tx = await fromWallet.otherMethods.makeTx(makeTxParams)
-      if (tx.savedAction == null) {
-        tx.savedAction = makeTxParams.metadata?.savedAction
+      if (
+        tx.savedAction == null &&
+        makeTxParams.metadata?.savedAction != null
+      ) {
+        tx.savedAction = makeTxParams.metadata.savedAction
       }
-      if (tx.assetAction == null) {
-        tx.assetAction = makeTxParams.metadata?.assetAction
+      if (
+        tx.assetAction == null &&
+        makeTxParams.metadata?.assetAction != null
+      ) {
+        tx.assetAction = makeTxParams.metadata.assetAction
       }
     } else {
       const { assetAction, savedAction } = makeTxParams
@@ -103,7 +109,6 @@ export async function makeSwapPluginQuote(
         tx.assetAction = assetAction
       }
     }
-
     if (tx.tokenId == null) {
       tx.tokenId = request.fromTokenId
     }
@@ -277,7 +282,7 @@ export const customFeeCache = {
   setFees: (uid: string, customNetworkFee?: JsonObject): void => {
     for (const id of Object.keys(customFeeCacheMap)) {
       if (Date.now() > customFeeCacheMap[id].timestamp + 30000) {
-        delete customFeeCacheMap[id] // eslint-disable-line
+        delete customFeeCacheMap[id]; // eslint-disable-line
       }
     }
     customFeeCacheMap[uid] = { customNetworkFee, timestamp: Date.now() }


### PR DESCRIPTION
- Add SUI to getParentTokenContractAddress() with native token address
- Add SUI to MAINNET_CODE_TRANSCRIPTION mapping
- Add SUI transaction request cleaner (asTransactionRequestSui)
- Implement SUI-specific transaction building logic
- Handle SUI transactions similar to Solana (no approval needed)
- Update CHANGELOG.md with feature addition

SUI is now supported for DEX swaps through the LI.FI plugin with chain ID 9270000000000000

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210756559961635