### PR TITLE
Add xgram support

### DIFF
--- a/src/swap/central/xgram.ts
+++ b/src/swap/central/xgram.ts
@@ -214,11 +214,14 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       return {
         id: quoteReply.id,
         validUntil: quoteReply.expiresAt,
-        fromAmount: quoteReply.ccyAmountFrom,
-        toAmount:
-          quoteReply.ccyAmountToExpected != null
+        fromAmount: isSelling
+          ? quoteReply.ccyAmountFrom
+          : quoteReply.ccyAmountToExpected ?? largeDenomAmount,
+        toAmount: isSelling
+          ? quoteReply.ccyAmountToExpected != null
             ? quoteReply.ccyAmountToExpected.toString()
-            : largeDenomAmount,
+            : largeDenomAmount
+          : quoteReply.ccyAmountFrom,
         payinAddress: quoteReply.depositAddress,
         payinExtraId: quoteReply.depositTag
       }


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches swap quote amount mapping for the reverse Xgram endpoint; wrong mapping would misstate send/receive amounts on fixed “quote for to” swaps.
> 
> **Overview**
> Fixes **Xgram** quote mapping when the user requests a **destination-side** (`quoteFor === 'to'`) swap via the reverse `launch-new-payment-exchange-edge` flow.
> 
> `createOrder` now branches on `isSelling`: sell quotes still map `fromAmount`/`toAmount` from `ccyAmountFrom` and `ccyAmountToExpected`, while reverse quotes **swap** those API fields so `fromAmount` reflects what the user must send and `toAmount` reflects the fixed payout (using `ccyAmountToExpected` or the requested `largeDenomAmount` when needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 948249648d580fb6212a338e88489c55b1de812a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->