### PR TITLE
fix(nexchange): normalize swap native amounts to integers

### DIFF
--- a/src/swap/central/nexchange.ts
+++ b/src/swap/central/nexchange.ts
@@ -1,4 +1,4 @@
-import { gt, lt } from 'biggystring'
+import { floor, gt, lt } from 'biggystring'
 import {
   asArray,
   asDate,
@@ -404,16 +404,20 @@ export function makeNexchangePlugin(
     }
 
     // Calculate amounts
-    const amountExpectedFromNative = denominationToNative(
+    const amountExpectedFromNativeRaw = denominationToNative(
       request.fromWallet,
       order.deposit_amount,
       request.fromTokenId
     )
-    const amountExpectedToNative = denominationToNative(
+    const amountExpectedToNativeRaw = denominationToNative(
       request.toWallet,
       order.withdraw_amount,
       request.toTokenId
     )
+    // This provider may return more decimal places than the token supports.
+    // Native amounts must be integer atomic units, so round down only.
+    const amountExpectedFromNative = floor(amountExpectedFromNativeRaw, 0)
+    const amountExpectedToNative = floor(amountExpectedToNativeRaw, 0)
 
     const memos: EdgeMemo[] =
       order.deposit_address_extra_id == null ||


### PR DESCRIPTION
N.exchange can return decimal amounts with more precision than the target asset supports, which leaks fractional values into native amount fields.

Rounding to integer atomic units in this plugin keeps spend targets and saved swap metadata valid for Edge amount expectations.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches swap amount calculation used to build `spendTargets` and saved swap metadata; incorrect rounding could cause under/over-payment or mismatched expectations. Change is small and uses conservative floor-to-integer behavior to avoid fractional native amounts.
> 
> **Overview**
> Normalizes N.exchange order `deposit_amount`/`withdraw_amount` conversions to **integer native (atomic) units** by applying `floor(..., 0)` after `denominationToNative`.
> 
> This prevents fractional native amounts (from provider over-precision) from leaking into `spendTargets` and persisted swap `fromAsset`/`toAsset` amounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6acb8fd80b09d129504ba9766432af2af22dfd29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213980990630960