### PR TITLE
exch: Migrate Thorchain endpoints off NineRealms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: Migrate Thorchain swap endpoints off NineRealms (thornode, tx tracker, Midgard sync fallback).
+
 ## 2.45.0 (2026-04-10)
 
 - added: Support Bitcoin Cash, Ethereum, and BNB Chain in Bridgeless swap plugin

--- a/scripts/synchronizers/thorchain/thorchainSynchronizer.ts
+++ b/scripts/synchronizers/thorchain/thorchainSynchronizer.ts
@@ -7,7 +7,7 @@ import { asThorchainPoolsResponse } from './thorchainTypes'
 
 // Fallback Midgard servers (try multiple endpoints)
 const MIDGARD_SERVERS = [
-  'https://midgard.ninerealms.com',
+  'https://gateway.liquify.com/chain/thorchain_midgard',
   'https://midgard.thorchain.info'
 ]
 

--- a/src/swap/defi/thorchain/thorchain.ts
+++ b/src/swap/defi/thorchain/thorchain.ts
@@ -18,11 +18,11 @@ const swapInfo: EdgeSwapInfo = {
   displayName: 'Thorchain',
   supportEmail: 'support@edge.app'
 }
-const orderUri = 'https://track.ninerealms.com/{{TXID}}'
+const orderUri = 'https://track.thorchain.org/{{TXID}}'
 
 const MIDGARD_SERVERS_DEFAULT = ['https://midgard.thorchain.info']
 export const THORNODE_SERVERS_DEFAULT = [
-  'https://thornode.ninerealms.com/thorchain'
+  'https://gateway.liquify.com/chain/thorchain_api/thorchain'
 ]
 
 const infoServer: {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1214112278221812/f)

Migrates Thorchain swap endpoints off `*.ninerealms.com` — those hosts are being retired on 2026-04-20 (they already return 301). Without this change Thorchain swap quoting and the order-tracking link will break.

Changes:
- `src/swap/defi/thorchain/thorchain.ts`
  - `orderUri`: `track.ninerealms.com/{TXID}` → `track.thorchain.org/{TXID}` (same path format, tx lookups return 200)
  - `THORNODE_SERVERS_DEFAULT[0]`: `thornode.ninerealms.com/thorchain` → `gateway.liquify.com/chain/thorchain_api/thorchain` (Liquify's new primary endpoint)
- `scripts/synchronizers/thorchain/thorchainSynchronizer.ts`
  - Fallback Midgard server 0: `midgard.ninerealms.com` → `gateway.liquify.com/chain/thorchain_midgard`

Kept intact (intentional):
- `ninerealmsClientId` init option + `x-client-id` header — the new Liquify endpoints accept the header without issue; stripping it is a larger-surface config change for a separate PR.
- `midgard.thorchain.info` as a fallback — not on ninerealms.

Stagenet and `thorchainrune` currency / Savers endpoints are handled in the sibling PRs in `edge-currency-accountbased` and `edge-react-gui`.

Asana parent: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1214109247963126

### Testing

Verified new endpoints with curl + existing `ninerealmsClientId`:
- `gateway.liquify.com/chain/thorchain_api/thorchain/network` → 200 OK
- `gateway.liquify.com/chain/thorchain_midgard/v2/health` → 200 OK
- `track.thorchain.org/<txid>` → 200 OK
- All `*.ninerealms.com` now return 301

Reviewer should confirm swap quotes + order tracker link open correctly on a mainnet Thorchain swap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Endpoint changes affect swap quoting, order-tracking links, and mapping sync; risk is mostly around availability/compatibility of the new upstream hosts and any subtle URL/path differences.
> 
> **Overview**
> Migrates the Thorchain swap plugin and Thorchain mapping synchronizer off retiring `*.ninerealms.com` hosts.
> 
> Updates the default Thornode API base URL to Liquify’s gateway, switches the order-tracking `orderUri` to `track.thorchain.org`, and replaces the synchronizer’s primary Midgard fallback with Liquify’s Midgard gateway. Adds a corresponding **Unreleased** changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb254d79dd3aa742e96ff37d2e281e9abb85b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->