### PR TITLE
Add NYM swap provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: NYM centralized swap integration
+
 ## 2.48.3 (2026-07-03)
 
 - fixed: (Xgram) Fall back to a float-rate estimate quote when the provider rejects fixed-rate order creation, which currently blocks all Xgram quotes.
@@ -28,7 +30,6 @@
 - changed: Pin ethers to exactly 5.7.0.
 - changed: Upgrade edge-core-js, edge-currency-accountbased, and edge-currency-plugins to their npm-published versions (removes transitive git dependencies).
 - security: Upgrade dependencies per Socket security recommendations.
-
 ## 2.46.0 (2026-04-18)
 
 - changed: Migrate Thorchain swap endpoints off NineRealms (thornode, tx tracker, Midgard sync fallback).

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { makeExolixPlugin } from './swap/central/exolix'
 import { makeGodexPlugin } from './swap/central/godex'
 import { makeLetsExchangePlugin } from './swap/central/letsexchange'
 import { makeNexchangePlugin } from './swap/central/nexchange'
+import { makeNymPlugin } from './swap/central/nym'
 import { makeSideshiftPlugin } from './swap/central/sideshift'
 import { makeSwapuzPlugin } from './swap/central/swapuz'
 import { makeXgramPlugin } from './swap/central/xgram'
@@ -39,6 +40,7 @@ const plugins = {
   letsexchange: makeLetsExchangePlugin,
   lifi: makeLifiPlugin,
   nexchange: makeNexchangePlugin,
+  nymswap: makeNymPlugin,
   rango: makeRangoPlugin,
   sideshift: makeSideshiftPlugin,
   spookySwap: makeSpookySwapPlugin,

--- a/src/mappings/nym.ts
+++ b/src/mappings/nym.ts
@@ -1,0 +1,35 @@
+/**
+ * NYM Exchange Plugin Chain Mapping
+ *
+ * Maps EdgeCurrencyPluginId -> NYM `chainNetwork` identifier (or null when the
+ * chain is not offered by NYM).
+ *
+ * NYM exposes an "Edge Partner API" whose asset references mirror Edge's own
+ * model: a `chainNetwork` string, an optional EVM `chainId`, and an optional
+ * `tokenId` (the 0x contract address). `chainNetwork` is the network *family*
+ * name; for EVM chains the `chainId` (taken from the wallet's `evmChainId` at
+ * quote time) distinguishes one EVM network from another. On the livenet API,
+ * Ethereum mainnet is `chainNetwork: 'ethereum'` + `chainId: 1`, which is why
+ * the Edge `ethereum` pluginId maps to `'ethereum'` below; the same entry also
+ * covers Ethereum tokens (USDT, USDC, ERC-20 NYM) via the wallet's contract
+ * address supplied at quote time.
+ *
+ * Every NYM swap must have the NYM asset (native NYM on `chainNetwork: 'nyx'`,
+ * Edge pluginId `nym`) on one side; this is enforced in ../swap/central/nym.ts.
+ *
+ * The authoritative list of supported assets is `GET /api/partner/v1/currencies`;
+ * the entries below reflect the current livenet list (BTC, Ethereum ETH/USDT/USDC
+ * /ERC-20 NYM, native NYM). Add more chains here as NYM enables them on livenet.
+ *
+ * See https://nym-swap-api.nymtech.cc/api/docs/ for the API docs.
+ */
+
+import { EdgeCurrencyPluginId } from '../util/edgeCurrencyPluginIds'
+
+export const nym = new Map<EdgeCurrencyPluginId, string | null>()
+nym.set('bitcoin', 'bitcoin')
+// Ethereum mainnet; chainId 1 is supplied from the wallet's evmChainId at quote
+// time. Also covers Ethereum tokens (USDT, USDC, ERC-20 NYM) via their tokenId.
+nym.set('ethereum', 'ethereum')
+// The NYM asset itself: native NYM on the Nyx chain.
+nym.set('nym', 'nyx')

--- a/src/swap/central/nym.ts
+++ b/src/swap/central/nym.ts
@@ -1,0 +1,432 @@
+import { gt, lt } from 'biggystring'
+import {
+  asArray,
+  asDate,
+  asMaybe,
+  asObject,
+  asOptional,
+  asString
+} from 'cleaners'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyWallet,
+  EdgeMemo,
+  EdgeSpendInfo,
+  EdgeSwapInfo,
+  EdgeSwapPlugin,
+  EdgeSwapQuote,
+  EdgeSwapRequest,
+  SwapAboveLimitError,
+  SwapBelowLimitError,
+  SwapCurrencyError,
+  SwapPermissionError
+} from 'edge-core-js/types'
+
+import { nym as nymMapping } from '../../mappings/nym'
+import { EdgeCurrencyPluginId } from '../../util/edgeCurrencyPluginIds'
+import {
+  checkInvalidTokenIds,
+  checkWhitelistedMainnetCodes,
+  CurrencyPluginIdSwapChainCodeMap,
+  ensureInFuture,
+  getContractAddresses,
+  getMaxSwappable,
+  makeSwapPluginQuote,
+  mapToRecord,
+  SwapOrder
+} from '../../util/swapHelpers'
+import { convertRequest, getAddress, memoType } from '../../util/utils'
+import { EdgeSwapRequestPlugin } from '../types'
+
+// Swap plugin id. Distinct from the `nym` *currency* plugin id (edge-core-js
+// keys all plugins in one namespace), mirroring how the Thorchain swap plugin
+// (`thorchain`) differs from the `thorchainrune` currency plugin.
+const pluginId = 'nymswap'
+
+// Edge pluginId of the NYM *asset/currency*. NYM provides its own liquidity, so
+// every swap must have the NYM asset on one side (enforced below).
+const NYM_PLUGIN_ID = 'nym'
+
+export const swapInfo: EdgeSwapInfo = {
+  pluginId,
+  isDex: false,
+  displayName: 'NYM',
+  supportEmail: 'support@nymtech.net'
+}
+
+const asInitOptions = asObject({
+  apiKey: asString
+})
+
+// NYM's production ("livenet") partner API. Request/response shapes and the
+// quote/order paths are identical to the earlier testnet backend; only the host
+// differs.
+const NYM_API_BASE = 'https://nym-swap-api.nymtech.cc'
+// User-facing order-tracking page. Built from this trusted constant rather than
+// the partner-supplied `statusUrl`, so a compromised upstream cannot inject an
+// attacker-controlled host/scheme into the saved swap action.
+const ORDER_URI = 'https://swap.nym.com/orderStatus/'
+
+const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = mapToRecord(
+  nymMapping
+)
+
+/**
+ * NYM asset reference, mirroring Edge's own asset model. `chainNetwork` is the
+ * NYM network-family name, `chainId` is the EVM chain id (omitted for non-EVM
+ * chains), and `tokenId` is the 0x contract address (null for a native asset).
+ */
+interface NymAssetRef {
+  chainNetwork: string
+  chainId?: number
+  tokenId: string | null
+}
+
+const asNymQuote = asObject({
+  quoteId: asString,
+  sourceAmount: asString,
+  destinationAmount: asString,
+  rate: asString,
+  expiresAt: asDate,
+  minSourceAmount: asString,
+  maxSourceAmount: asString,
+  minDestinationAmount: asString,
+  maxDestinationAmount: asString
+})
+
+const asNymOrder = asObject({
+  orderId: asString,
+  status: asString,
+  payinAddress: asString,
+  payinExtraId: asOptional(asString),
+  expiresAt: asDate
+  // `statusUrl` is intentionally not consumed: the order-tracking URL is built
+  // from the trusted ORDER_URI constant to avoid trusting a partner-supplied
+  // host/scheme.
+})
+
+// Error bodies come in two shapes:
+//   { errors: [{ error: 'InvalidRequest' | 'AssetNotSupported', message }] }
+//   { error: 'Quote rate limit exceeded ...' }
+const asNymErrorArray = asObject({
+  errors: asArray(asObject({ error: asString, message: asOptional(asString) }))
+})
+const asNymSimpleError = asObject({ error: asString })
+
+/**
+ * Builds a NYM asset reference from an Edge wallet. `contractAddress` is the
+ * token's 0x contract address (undefined for a native asset). Returns null if
+ * the wallet's chain is not mapped to a NYM `chainNetwork`.
+ */
+const getAssetRef = (
+  wallet: EdgeCurrencyWallet,
+  contractAddress: string | undefined
+): NymAssetRef | null => {
+  const chainNetwork =
+    MAINNET_CODE_TRANSCRIPTION[
+      wallet.currencyInfo.pluginId as EdgeCurrencyPluginId
+    ]
+  if (chainNetwork == null) return null
+
+  const evmChainId = wallet.currencyInfo.evmChainId
+  return {
+    chainNetwork,
+    ...(evmChainId != null ? { chainId: evmChainId } : {}),
+    tokenId: contractAddress ?? null
+  }
+}
+
+export function makeNymPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
+  const { io, log } = opts
+  const { apiKey } = asInitOptions(opts.initOptions)
+  const fetchCors = io.fetchCors ?? io.fetch
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'x-api-key': apiKey
+  }
+
+  /**
+   * Maps a non-OK NYM response to the appropriate swap error. Bodies are parsed
+   * when present; otherwise classification falls back to the status code.
+   */
+  const handleErrorResponse = async (
+    response: { status: number; text: () => Promise<string> },
+    request: EdgeSwapRequestPlugin,
+    stage: 'quote' | 'order'
+  ): Promise<never> => {
+    const text = await response.text().catch(() => '')
+    log.warn(`NYM ${stage} error ${response.status}: ${text}`)
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch (e: unknown) {
+      parsed = undefined
+    }
+
+    const errorArray = asMaybe(asNymErrorArray)(parsed)
+    if (errorArray != null) {
+      const message = errorArray.errors
+        .map(e => e.message ?? e.error)
+        .join('; ')
+      // Region / geographic restriction.
+      if (/region|geo|country|blocked|jurisdiction/i.test(message)) {
+        throw new SwapPermissionError(swapInfo, 'geoRestriction')
+      }
+      // Unsupported asset or pair/direction (e.g. selling NYM to a UTXO chain).
+      throw new SwapCurrencyError(swapInfo, request)
+    }
+
+    // 403 with no parsable error body: treat as a permission restriction.
+    if (response.status === 403) {
+      throw new SwapPermissionError(swapInfo, 'geoRestriction')
+    }
+
+    // { error: 'message' } (e.g. 429 rate limiting) or anything else: transient.
+    const simpleError = asMaybe(asNymSimpleError)(parsed)
+    throw new Error(
+      `NYM ${stage} returned error code ${response.status}${
+        simpleError != null ? `: ${simpleError.error}` : ''
+      }`
+    )
+  }
+
+  /**
+   * Quote step: gate the pair, resolve asset refs + addresses, fetch a quote, and
+   * enforce the quote's native-unit min/max. Creates NO order, so it is safe to
+   * run as the `getMaxSwappable` probe, which would otherwise create (and abandon)
+   * a live NYM order on every max-swap request (see `fetchProbeOrder`).
+   *
+   * `enforceMax` is false only for the probe: a max-swap probe intentionally
+   * quotes the full pre-fee balance to discover the ceiling, so an above-limit
+   * balance must clamp via `getMaxSpendable` rather than throw `SwapAboveLimitError`
+   * on the raw balance.
+   */
+  const fetchQuote = async (
+    request: EdgeSwapRequestPlugin,
+    enforceMax: boolean
+  ): Promise<{
+    quote: ReturnType<typeof asNymQuote>
+    refundAddress: string
+    payoutAddress: string
+  }> => {
+    const { fromWallet, toWallet, quoteFor } = request
+
+    // NYM provides its own liquidity: one side of the swap must be NYM. Gate
+    // locally so unrelated pairs never reach (and rate-limit) the API.
+    if (
+      fromWallet.currencyInfo.pluginId !== NYM_PLUGIN_ID &&
+      toWallet.currencyInfo.pluginId !== NYM_PLUGIN_ID
+    ) {
+      throw new SwapCurrencyError(swapInfo, request)
+    }
+
+    // NYM identifies tokens by their 0x contract address, not the Edge tokenId.
+    const { fromContractAddress, toContractAddress } = getContractAddresses(
+      request
+    )
+
+    const from = getAssetRef(fromWallet, fromContractAddress)
+    const to = getAssetRef(toWallet, toContractAddress)
+    if (from == null || to == null) {
+      throw new SwapCurrencyError(swapInfo, request)
+    }
+
+    // Grab addresses:
+    const [refundAddress, payoutAddress] = await Promise.all([
+      getAddress(fromWallet),
+      getAddress(toWallet)
+    ])
+
+    // NYM amounts are in native units (matching Edge's nativeAmount), so no
+    // denomination conversion is required.
+    const quoteBody =
+      quoteFor === 'to'
+        ? { from, to, destinationAmount: request.nativeAmount }
+        : { from, to, sourceAmount: request.nativeAmount }
+
+    const quoteResponse = await fetchCors(
+      `${NYM_API_BASE}/api/partner/v1/quote`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(quoteBody)
+      }
+    )
+
+    if (!quoteResponse.ok) {
+      await handleErrorResponse(quoteResponse, request, 'quote')
+    }
+
+    const quote = asNymQuote(await quoteResponse.json())
+
+    // Enforce the min/max limits returned by the quote against the user's
+    // requested amount (NYM returns native-unit limits for both sides).
+    // Compare `request.nativeAmount`, not the quote's echoed amount, so a
+    // clamped quote that omits an error still trips the limit error.
+    const [min, max, side] =
+      quoteFor === 'to'
+        ? ([
+            quote.minDestinationAmount,
+            quote.maxDestinationAmount,
+            'to'
+          ] as const)
+        : ([quote.minSourceAmount, quote.maxSourceAmount, 'from'] as const)
+    if (lt(request.nativeAmount, min)) {
+      throw new SwapBelowLimitError(swapInfo, min, side)
+    }
+    if (enforceMax && gt(request.nativeAmount, max)) {
+      throw new SwapAboveLimitError(swapInfo, max, side)
+    }
+
+    return { quote, refundAddress, payoutAddress }
+  }
+
+  /**
+   * `getMaxSwappable` probe: build a SwapOrder from a quote alone, targeting the
+   * user's own from-chain refund address so `getMaxSpendable` can estimate fees
+   * WITHOUT creating a live NYM order. The trimmed amount it computes is then run
+   * through the real `fetchSwapQuoteInner`, which creates exactly one order.
+   */
+  const fetchProbeOrder = async (
+    request: EdgeSwapRequestPlugin
+  ): Promise<SwapOrder> => {
+    const { quote, refundAddress } = await fetchQuote(request, false)
+    const spendInfo: EdgeSpendInfo = {
+      tokenId: request.fromTokenId,
+      spendTargets: [
+        {
+          nativeAmount: quote.sourceAmount,
+          publicAddress: refundAddress
+        }
+      ],
+      networkFeeOption: 'high',
+      assetAction: {
+        assetActionType: 'swap'
+      }
+    }
+    return {
+      request,
+      spendInfo,
+      swapInfo,
+      fromNativeAmount: quote.sourceAmount,
+      expirationDate: ensureInFuture(quote.expiresAt)
+    }
+  }
+
+  const fetchSwapQuoteInner = async (
+    request: EdgeSwapRequestPlugin
+  ): Promise<SwapOrder> => {
+    const { fromWallet, toWallet } = request
+
+    const { quote, refundAddress, payoutAddress } = await fetchQuote(
+      request,
+      true
+    )
+
+    // Create the order from the quote:
+    const orderResponse = await fetchCors(
+      `${NYM_API_BASE}/api/partner/v1/order`,
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          quoteId: quote.quoteId,
+          payoutAddress,
+          refundAddress
+        })
+      }
+    )
+
+    if (!orderResponse.ok) {
+      await handleErrorResponse(orderResponse, request, 'order')
+    }
+
+    const order = asNymOrder(await orderResponse.json())
+
+    const fromNativeAmount = quote.sourceAmount
+    const toNativeAmount = quote.destinationAmount
+
+    const memos: EdgeMemo[] =
+      order.payinExtraId == null || order.payinExtraId === ''
+        ? []
+        : [
+            {
+              type: memoType(fromWallet.currencyInfo.pluginId),
+              value: order.payinExtraId
+            }
+          ]
+
+    const spendInfo: EdgeSpendInfo = {
+      tokenId: request.fromTokenId,
+      spendTargets: [
+        {
+          nativeAmount: fromNativeAmount,
+          publicAddress: order.payinAddress
+        }
+      ],
+      memos,
+      networkFeeOption: 'high',
+      assetAction: {
+        assetActionType: 'swap'
+      },
+      savedAction: {
+        actionType: 'swap',
+        swapInfo,
+        orderId: order.orderId,
+        orderUri: ORDER_URI + order.orderId,
+        isEstimate: false,
+        toAsset: {
+          pluginId: toWallet.currencyInfo.pluginId,
+          tokenId: request.toTokenId,
+          nativeAmount: toNativeAmount
+        },
+        fromAsset: {
+          pluginId: fromWallet.currencyInfo.pluginId,
+          tokenId: request.fromTokenId,
+          nativeAmount: fromNativeAmount
+        },
+        payoutAddress,
+        payoutWalletId: toWallet.id,
+        refundAddress
+      }
+    }
+
+    return {
+      request,
+      spendInfo,
+      swapInfo,
+      fromNativeAmount,
+      expirationDate: ensureInFuture(order.expiresAt)
+    }
+  }
+
+  const out: EdgeSwapPlugin = {
+    swapInfo,
+
+    async fetchSwapQuote(req: EdgeSwapRequest): Promise<EdgeSwapQuote> {
+      const request = convertRequest(req)
+
+      checkWhitelistedMainnetCodes(
+        MAINNET_CODE_TRANSCRIPTION,
+        request,
+        swapInfo
+      )
+      // Reject same-asset (self) swaps before hitting NYM's live endpoints. The
+      // NYM-on-one-side gate in fetchQuote is trivially satisfied by a native-NYM
+      // self-swap, so mirror the sibling central plugins' checkInvalidTokenIds
+      // guard, which includes the isSameAsset check.
+      checkInvalidTokenIds({ from: {}, to: {} }, request, swapInfo)
+
+      // Probe with a quote-only order (no live NYM order) so a max-swap does not
+      // create and abandon an extra order; the real order is created once below.
+      const newRequest = await getMaxSwappable(fetchProbeOrder, request)
+      const swapOrder = await fetchSwapQuoteInner(newRequest)
+      return await makeSwapPluginQuote(swapOrder)
+    }
+  }
+
+  return out
+}


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Integrate NYM as a centralized swap provider (`pluginId: nym`).

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1215306512581867

NYM provides its own swap liquidity, so every swap must have the NYM asset on one side. The plugin gates this locally before hitting the API to avoid offering NYM (and rate-limiting it) on unrelated pairs.

NYM exposes an Edge-shaped partner API, which keeps the plugin thin:

- **Native-unit amounts** — `sourceAmount`/`destinationAmount` are already in the chain's smallest unit (matching Edge's `nativeAmount`), so no denomination conversion is needed in either direction.
- **Edge-style asset references** — `{ chainNetwork, chainId?, tokenId? }`. `chainNetwork` is the network-family name (mapped from the Edge `pluginId`), `chainId` comes from the wallet's `evmChainId`, and `tokenId` is the **0x contract address** (not the Edge tokenId). Ethereum mainnet is represented as `chainNetwork: 'ethereum'` + `chainId: 1`.
- **Limits** — the quote response returns native-unit min/max for both sides; the plugin enforces them as `SwapBelowLimitError` / `SwapAboveLimitError`.
- **Errors** — NYM's JSON error bodies (`{ errors: [{ error, message }] }` and `{ error }`) are parsed into `SwapCurrencyError` / `SwapPermissionError`, with rate-limit/other failures surfaced as transient errors.

Files:
- `src/swap/central/nym.ts` — the provider.
- `src/mappings/nym.ts` — `EdgeCurrencyPluginId → chainNetwork`, scoped to the current livenet asset list (BTC, Ethereum ETH/USDT/USDC/ERC-20 NYM, native NYM on `nyx`).
- `src/index.ts` — registers `nym: makeNymPlugin`.

**Livenet.** Base URL points at the NYM production API (`https://nym-swap-api.nymtech.cc`) and the order-tracking link at `https://swap.nym.com/orderStatus/`. The mapping reflects the current `GET /currencies` list and should be expanded here as NYM enables more chains. The init option is `{ apiKey }` (header `x-api-key`).

**Verified end-to-end in the iOS simulator** (edge-react-gui, linked via updot): ran a real mainnet swap My Ether 4 (USDT on Ethereum) → My Nym (native NYM on Nyx). The quote resolved "Powered by NYM" (6.006 USDT → 326.99 NYM), slide-to-confirm broadcast the on-chain payin (max network fee 0.0002709 ETH), and the order entered processing ("Congratulations! Your exchange is being processed", tx category `Exchange: To NYM`, 6.006 USDT → 326.993333 NYM fixed quote). Also validated the raw livenet API directly (`GET /currencies`, `POST /quote` → `POST /order`).

**pluginId note:** the swap plugin is registered as `nymswap`, deliberately distinct from the `nym` *currency* plugin — edge-core-js keys all plugins in one namespace, so reusing `nym` silently dropped the swap plugin (mirrors how the Thorchain swap plugin `thorchain` differs from the `thorchainrune` currency). This was caught by the in-sim test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New third-party swap integration that creates real pay-in orders and handles API keys and user addresses, though it follows existing centralized-plugin patterns and includes local pair gating and trusted order URLs.
> 
> **Overview**
> Adds a **NYM** centralized swap provider registered as `nymswap` (separate from the `nym` currency plugin), with a CHANGELOG entry.
> 
> The plugin talks to NYM’s livenet partner API (`quote` → `order`) using an `apiKey` init option. Swaps are only offered when **NYM is on one side** of the pair; supported chains are mapped in `src/mappings/nym.ts` (currently Bitcoin, Ethereum mainnet/tokens, and native NYM on Nyx). Quotes use native-unit amounts and enforce min/max limits; API errors map to `SwapCurrencyError` / `SwapPermissionError` where appropriate.
> 
> **Max-swap** uses a quote-only probe so `getMaxSwappable` does not create and abandon live NYM orders. Order status links are built from a fixed `ORDER_URI` rather than the partner’s `statusUrl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9480ffb1cc4315f4126eb8074ec350eda14b4c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

