### PR TITLE
Add transparent refund address for shielded Zcash Maya swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: (Maya) Include a transparent refund address in the swap memo for shielded Zcash sources so Maya can process refunds.
+
 ## 2.52.2 (2026-07-27)
 
 - fixed: Maya swaps spending RUNE now send to Maya's inbound address instead of depositing into THORChain's own state machine, which misrouted the swap (THORChain read Maya's `=:d:` DASH memo as an unparseable DOGE swap and the deposit failed).

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -889,12 +889,16 @@ export function makeThorchainBasedPlugin(
         fromCurrencyCode
       )
 
+      // Maya cannot refund a shielded Zcash source without a transparent refund
+      // address. This is the Zcash-only path, so it must be present.
+      if (refundAddress == null || refundAddress === '') {
+        throw new SwapCurrencyError(swapInfo, request)
+      }
+
       // Inject the transparent refund address into the shielded ZEC swap memo,
       // which is fetched from the quote endpoint without it (see
       // `appendMayaRefundAddress`).
-      if (refundAddress != null) {
-        memo = appendMayaRefundAddress(memo, refundAddress)
-      }
+      memo = appendMayaRefundAddress(memo, toAddress, refundAddress)
 
       // Encode memo per ZIP-321 as base64url (unpadded).
       const memoBase64Url = base64urlnopad.encode(utf8.decode(memo))
@@ -1621,19 +1625,17 @@ export const getVolatilitySpread = ({
  * note (512 bytes), which is not bound by that limit, so the refund is appended
  * here after the quote is fetched without it.
  *
- * The memo shape is `=:ASSET:DESTADDR:...`, so the refund is appended to the
- * destination field (index 2). A memo with no destination field is returned
- * unchanged.
+ * Maya reads the refund from the memo's destination field as
+ * `DESTADDR/REFUNDADDR`, so the destination address in the memo is replaced
+ * with `DESTADDR/REFUNDADDR`. A memo that does not contain the destination
+ * address is returned unchanged.
  */
 export const appendMayaRefundAddress = (
   memo: string,
+  destinationAddress: string,
   refundAddress: string
-): string => {
-  const memoFields = memo.split(':')
-  if (memoFields.length <= 2) return memo
-  memoFields[2] = `${memoFields[2]}/${refundAddress}`
-  return memoFields.join(':')
-}
+): string =>
+  memo.replace(destinationAddress, `${destinationAddress}/${refundAddress}`)
 
 /**
  * This will return the expected amount out from the quote maintaining backwards

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -451,6 +451,16 @@ export function makeThorchainBasedPlugin(
         : undefined
     )
 
+    // Maya cannot refund a shielded Zcash source without a transparent
+    // (t-address) refund address; other chains default to the sending address,
+    // which is correct, so no refund address is needed. The address is injected
+    // into the ZEC swap memo below via `appendMayaRefundAddress` (see that
+    // helper for why it is not passed to the quote endpoint).
+    const refundAddress =
+      fromWallet.currencyInfo.pluginId === 'zcash'
+        ? await getAddress(fromWallet, 'transparentAddress')
+        : undefined
+
     const fromMainnetCode =
       MAINNET_CODE_TRANSCRIPTION[fromWallet.currencyInfo.pluginId]
     const toMainnetCode =
@@ -879,18 +889,12 @@ export function makeThorchainBasedPlugin(
         fromCurrencyCode
       )
 
-      // Debug logging for Maya ZEC ZIP-321 construction
-      log(
-        '[MAYA ZEC] zip321 components ' +
-          JSON.stringify({
-            chain: fromCurrencyCode,
-            inbound_address: thorAddress,
-            memo_ascii: memo,
-            memo_recipient: memoRecipient,
-            amount_native: fromNativeAmount,
-            amount_decimal: amountZec
-          })
-      )
+      // Inject the transparent refund address into the shielded ZEC swap memo,
+      // which is fetched from the quote endpoint without it (see
+      // `appendMayaRefundAddress`).
+      if (refundAddress != null) {
+        memo = appendMayaRefundAddress(memo, refundAddress)
+      }
 
       // Encode memo per ZIP-321 as base64url (unpadded).
       const memoBase64Url = base64urlnopad.encode(utf8.decode(memo))
@@ -1601,6 +1605,34 @@ export const getVolatilitySpread = ({
   }
 
   return volatilitySpreadFinal.toString()
+}
+
+/**
+ * Append a transparent (t-address) refund address to a Maya swap memo for a
+ * shielded Zcash source.
+ *
+ * Maya cannot refund a shielded Zcash source without a transparent refund
+ * address, which it reads from the swap memo's destination field as
+ * `DESTADDR/REFUNDADDR`. The address cannot be obtained from the quote/swap
+ * endpoint: given a `refund_address`, Maya builds that same memo and then
+ * rejects the quote because the result overflows Zcash's 80-char
+ * transparent-memo limit (e.g. ZEC->DASH is 86/80, verified against the live
+ * endpoint). The shielded Zcash send instead carries the memo in the encrypted
+ * note (512 bytes), which is not bound by that limit, so the refund is appended
+ * here after the quote is fetched without it.
+ *
+ * The memo shape is `=:ASSET:DESTADDR:...`, so the refund is appended to the
+ * destination field (index 2). A memo with no destination field is returned
+ * unchanged.
+ */
+export const appendMayaRefundAddress = (
+  memo: string,
+  refundAddress: string
+): string => {
+  const memoFields = memo.split(':')
+  if (memoFields.length <= 2) return memo
+  memoFields[2] = `${memoFields[2]}/${refundAddress}`
+  return memoFields.join(':')
 }
 
 /**

--- a/test/thorchain.test.ts
+++ b/test/thorchain.test.ts
@@ -9,9 +9,10 @@ import {
 describe(`appendMayaRefundAddress`, function () {
   const refund = 't1MnUkHpi3Ampr9ZzAtnWHFbatsVF3hEvKL'
 
-  it('appends the refund to the destination field of a Maya memo', function () {
-    const memo = '=:d:XnzErKGuqcG5Ci5oTsQv7stwCBofgChu8s:0/1/1:ej:75'
-    const result = appendMayaRefundAddress(memo, refund)
+  it('replaces the destination address with destination/refund', function () {
+    const destination = 'XnzErKGuqcG5Ci5oTsQv7stwCBofgChu8s'
+    const memo = `=:d:${destination}:0/1/1:ej:75`
+    const result = appendMayaRefundAddress(memo, destination, refund)
     assert.equal(
       result,
       '=:d:XnzErKGuqcG5Ci5oTsQv7stwCBofgChu8s/t1MnUkHpi3Ampr9ZzAtnWHFbatsVF3hEvKL:0/1/1:ej:75'
@@ -19,23 +20,22 @@ describe(`appendMayaRefundAddress`, function () {
   })
 
   it('leaves the asset and trailing fields untouched', function () {
-    const memo = '=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e::ej:75'
-    const result = appendMayaRefundAddress(memo, refund)
+    const destination = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e'
+    const memo = `=:e:${destination}::ej:75`
+    const result = appendMayaRefundAddress(memo, destination, refund)
     const fields = result.split(':')
     // index 1 (asset) and the affiliate/bps tail are unchanged; only the
     // destination field (index 2) gains the refund.
     assert.equal(fields[1], 'e')
-    assert.equal(
-      fields[2],
-      `0x742d35Cc6634C0532925a3b844Bc454e4438f44e/${refund}`
-    )
+    assert.equal(fields[2], `${destination}/${refund}`)
     assert.equal(fields[4], 'ej')
     assert.equal(fields[5], '75')
   })
 
-  it('returns a memo with no destination field unchanged', function () {
-    assert.equal(appendMayaRefundAddress('=:d', refund), '=:d')
-    assert.equal(appendMayaRefundAddress('', refund), '')
+  it('returns the memo unchanged when the destination is not present', function () {
+    const memo = '=:d:XnzErKGuqcG5Ci5oTsQv7stwCBofgChu8s:0/1/1:ej:75'
+    assert.equal(appendMayaRefundAddress(memo, 'notinmemo', refund), memo)
+    assert.equal(appendMayaRefundAddress('', 'notinmemo', refund), '')
   })
 })
 

--- a/test/thorchain.test.ts
+++ b/test/thorchain.test.ts
@@ -1,7 +1,43 @@
 import { assert } from 'chai'
 import { describe, it } from 'mocha'
 
-import { getVolatilitySpread } from '../src/swap/defi/thorchain/thorchainCommon'
+import {
+  appendMayaRefundAddress,
+  getVolatilitySpread
+} from '../src/swap/defi/thorchain/thorchainCommon'
+
+describe(`appendMayaRefundAddress`, function () {
+  const refund = 't1MnUkHpi3Ampr9ZzAtnWHFbatsVF3hEvKL'
+
+  it('appends the refund to the destination field of a Maya memo', function () {
+    const memo = '=:d:XnzErKGuqcG5Ci5oTsQv7stwCBofgChu8s:0/1/1:ej:75'
+    const result = appendMayaRefundAddress(memo, refund)
+    assert.equal(
+      result,
+      '=:d:XnzErKGuqcG5Ci5oTsQv7stwCBofgChu8s/t1MnUkHpi3Ampr9ZzAtnWHFbatsVF3hEvKL:0/1/1:ej:75'
+    )
+  })
+
+  it('leaves the asset and trailing fields untouched', function () {
+    const memo = '=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e::ej:75'
+    const result = appendMayaRefundAddress(memo, refund)
+    const fields = result.split(':')
+    // index 1 (asset) and the affiliate/bps tail are unchanged; only the
+    // destination field (index 2) gains the refund.
+    assert.equal(fields[1], 'e')
+    assert.equal(
+      fields[2],
+      `0x742d35Cc6634C0532925a3b844Bc454e4438f44e/${refund}`
+    )
+    assert.equal(fields[4], 'ej')
+    assert.equal(fields[5], '75')
+  })
+
+  it('returns a memo with no destination field unchanged', function () {
+    assert.equal(appendMayaRefundAddress('=:d', refund), '=:d')
+    assert.equal(appendMayaRefundAddress('', refund), '')
+  })
+})
 
 describe(`getVolatilitySpread`, function () {
   it('bitcoin source', function () {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/0/1215088146871429/1214541361005860

**Problem.** When Edge sends a shielded-Zcash swap to Maya, the swap memo carries no refund address. Maya cannot refund a shielded source and rejects the refund:

```
can't refund ZEC from shielded source without a refund address
fail to refund for halted trading
```

For every chain except Zcash, Maya defaults the refund to the sending address, which is correct. A shielded ZEC source has no transparent sending address to refund to, so the integrator must supply a transparent (t-address) refund address in the swap memo.

**Fix.** In the shared Thorchain/Maya common code, when the source wallet is Zcash, fetch the wallet's transparent address (`getAddress(fromWallet, 'transparentAddress')`, the same helper already used for the ZEC receive side) and append it to the swap memo's destination field as `DESTADDR/REFUNDADDR` per the Maya memo spec, via the new documented helper `appendMayaRefundAddress` (which replaces the destination address in the memo with `DESTADDR/REFUNDADDR`). Since this is the Zcash-only path, the code throws `SwapCurrencyError` if the transparent refund address is missing.

The refund address is deliberately NOT passed to the `quote/swap` endpoint. Given a `refund_address`, Maya builds that same `DESTADDR/REFUNDADDR` memo and then rejects the quote because the result overflows the source chain's memo limit (e.g. ZEC to DASH is 86/80). The shielded ZEC send instead carries the memo in the encrypted note (512 bytes), which is not bound by the 80-char transparent-memo limit that the quote endpoint pre-validates against, so the refund is injected client-side after the quote is fetched without it. Non-Zcash sources are untouched and keep defaulting to the sending address (their quote requests and memos are unchanged).

The change lives entirely in the dependency; no gui-side wiring is required.

**Verification.**
- `tsc --noEmit`, eslint, and the mocha suite all pass (via `verify-repo.sh`, which also runs the webpack build).
- New unit tests in `test/thorchain.test.ts` pin `appendMayaRefundAddress`'s output to the exact memo shape (`=:d:DEST/REFUND:0/1/1:ej:75`) and cover the destination-not-present edge case.
- Live Maya node (`mayanode.mayachain.info`) confirms why the endpoint cannot build the memo: BTC to ETH with `refund_address` returns `generated memo too long for source chain: ...(96/80)`; the same request without it returns a valid 53-char memo.
- In-app ZEC to asset swap-to-success was driven to the success scene in the prior run (with the byte-identical memo). It could not be re-driven this pass: Maya ZEC trading is halted again (`HALTZECTRADING=1`, `trading is halted, can't process swap`) at the protocol level, and a swap during the halt fails at the quote before the refund injection runs, so it would not exercise this code anyway. Re-run the in-app smoke once Maya resumes ZEC trading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Maya Zcash swap memo construction and refund routing for a subset of swaps; wrong address formatting could misroute refunds, but scope is limited to ZEC source via the existing ZIP-321 path.
> 
> **Overview**
> **Shielded Zcash → Maya swaps** now embed a **transparent (t-address) refund** in the swap memo as `DESTADDR/REFUNDADDR`, so Maya can refund when trading is halted or the swap fails—shielded sources cannot default to the sender like other chains.
> 
> Quotes still call `quote/swap` **without** `refund_address`, because Maya would build the same long memo and reject quotes that exceed the **80-character transparent memo limit**; the shielded ZIP-321 path carries the memo in the encrypted note (512 bytes), so `appendMayaRefundAddress` patches the memo **after** quoting. Missing transparent refund address fails the swap with `SwapCurrencyError`.
> 
> Unit tests lock the memo shape; CHANGELOG notes the Maya behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f0430aee9e4c51c33d5791890df026e9f10e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
