### PR TITLE
Stringify Exolix swap error response for readable logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - changed: Convert the build tooling from Yarn to npm.
 - changed: Pin ethers to exactly 5.7.0.
 - security: Upgrade dependencies per Socket security recommendations.
+- fixed: (Exolix) Log readable JSON swap error responses instead of "[object Object]".
 
 ## 2.46.0 (2026-04-18)
 

--- a/src/swap/central/exolix.ts
+++ b/src/swap/central/exolix.ts
@@ -174,7 +174,7 @@ export function makeExolixPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
             return resJson
           }
 
-          log.warn(`Error retrieving Exolix quote: ${String(resJson)}`)
+          log.warn(`Error retrieving Exolix quote: ${JSON.stringify(resJson)}`)
           throw new SwapCurrencyError(swapInfo, request)
         }
         throw new Error(`Exolix returned error code ${response.status}`)


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Exolix's swap-quote error handler logged the raw API error response via `String(resJson)`. Because `resJson` is a plain object (`await response.json()`), `String()` coerced it to the literal `[object Object]`, hiding the actual reason a swap failed (e.g. ARRR→ETH) from the logs.

Switch the interpolation to `JSON.stringify(resJson)` so the underlying Exolix error payload is human-readable in logs. This line only fires on a 422 response that is not a recognized min-amount error, which is exactly the case where seeing the real payload matters; the thrown `SwapCurrencyError` is unchanged, so there is no behavioral change beyond log readability.

Before: `Error retrieving Exolix quote: [object Object]`
After: `Error retrieving Exolix quote: {"error":"Currency pair not available","code":"PAIR_UNAVAILABLE",...}`

Asana: https://app.asana.com/0/1215088146871429/1212885691958616

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change on a warn log line; no swap logic, error types, or API handling changed.
> 
> **Overview**
> **Exolix quote failures** on HTTP 422 (when the body is not a recognized min-amount shape) now log the full API JSON via `JSON.stringify(resJson)` instead of `String(resJson)`, which previously produced useless `[object Object]` messages.
> 
> Swap behavior is unchanged: the same path still throws `SwapCurrencyError`. The **Unreleased** CHANGELOG documents this logging fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5398fc6058c4c12fbbaa3d47e293360b507dfbf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- agent-test-evidence:start -->
### Test evidence

<table>
<tr>
<td rowspan="1" width="170" valign="top"><a href="https://github.com/EdgeApp/edge-exchange-plugins/pull/460/commits/5398fc6058c4c12fbbaa3d47e293360b507dfbf6"><code>5398fc6</code></a><br><sub>Stringify Exolix swap error response for readable logs</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-exchange-plugins/pr-460/20260612-181909-01-exolix-provider-enabled.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-exchange-plugins/pr-460/20260612-181909-01-exolix-provider-enabled.png" width="200"></a><br><sub>exolix provider enabled</sub></td>
<td width="210" valign="top" align="center"><a href="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-exchange-plugins/pr-460/20260612-181909-02-lld-to-eth-swap-rejected.png"><img src="https://raw.githubusercontent.com/EdgeApp/edge-dev-agents/agent-pr-assets/assets/edge-exchange-plugins/pr-460/20260612-181909-02-lld-to-eth-swap-rejected.png" width="200"></a><br><sub>lld to eth swap rejected</sub></td>
<td width="210"></td>
</tr>
</table>
<!-- agent-test-evidence:end -->