### PR TITLE
Append Rango request ID to order URI for all chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: (Rango) Sonic support
+- fixed: (Rango) Append the request ID to the order URI for all supported chains so swap explorer links open the specific transaction instead of the destination address history.
 
 ## 2.47.0 (2026-06-13)
 

--- a/src/swap/defi/rango.ts
+++ b/src/swap/defi/rango.ts
@@ -575,6 +575,16 @@ export function makeRangoPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       swapInfo
     }
 
+    // Use Rango's request ID for the order URI so the explorer link opens the
+    // specific swap. Fall back to the destination address (an address-history
+    // link) when no request ID is returned. Applies to every chain Rango
+    // supports, not just Cosmos.
+    const trackingId =
+      swap.requestId ?? swap.id ?? swap.uuid ?? swap.transactionId ?? ''
+    const orderUriValue =
+      trackingId !== '' ? `${orderUri}${trackingId}` : `${orderUri}${toAddress}`
+    log(`Rango tracking: id=${trackingId}, uri=${orderUriValue}`)
+
     switch (tx.type) {
       case 'SOLANA': {
         const solanaTransaction = asSolanaTransaction(tx)
@@ -608,7 +618,7 @@ export function makeRangoPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
           savedAction: {
             actionType: 'swap',
             swapInfo,
-            orderUri: `${orderUri}${toAddress}`,
+            orderUri: orderUriValue,
             isEstimate: true,
             toAsset: {
               pluginId: toWallet.currencyInfo.pluginId,
@@ -642,7 +652,7 @@ export function makeRangoPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
             savedAction: {
               actionType: 'swap',
               swapInfo,
-              orderUri: `${orderUri}${toAddress}`,
+              orderUri: orderUriValue,
               isEstimate: true,
               toAsset: {
                 pluginId: toWallet.currencyInfo.pluginId,
@@ -670,20 +680,11 @@ export function makeRangoPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
           throw new SwapCurrencyError(swapInfo, request)
         }
 
-        // Use requestId/id/uuid/transactionId for tracking if available
-        const trackingId =
-          swap.requestId ?? swap.id ?? swap.uuid ?? swap.transactionId ?? ''
-        const trackingUri =
-          trackingId !== ''
-            ? `${orderUri}${trackingId}`
-            : `${orderUri}${toAddress}`
-        log(`Rango tracking: id=${trackingId}, uri=${trackingUri}`)
-
         // Create the saved action for the swap
         const savedAction = {
           actionType: 'swap' as const,
           swapInfo,
-          orderUri: trackingUri,
+          orderUri: orderUriValue,
           isEstimate: true,
           toAsset: {
             pluginId: toWallet.currencyInfo.pluginId,
@@ -768,7 +769,7 @@ export function makeRangoPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
           savedAction: {
             actionType: 'swap',
             swapInfo,
-            orderUri: `${orderUri}${toAddress}`,
+            orderUri: orderUriValue,
             isEstimate: true,
             toAsset: {
               pluginId: toWallet.currencyInfo.pluginId,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1211064422811767/f)

The Cosmos branch of the Rango swap plugin already used Rango's request ID to build the order URI, so the explorer link opened the specific swap. The Solana, Sui, and EVM branches still used the destination address, which produced an address-history link instead of a link to the transaction.

This hoists the request-ID logic out of the Cosmos case so every chain Rango supports uses the same order URI. When Rango returns a request ID, the order URI becomes `https://explorer.rango.exchange/search?query=<requestId>`; it falls back to the destination address only when no request ID is present.

Verified in-app on iOS with a real executed swap: ETH to ETH (Base) routed through Rango Exchange (the EVM branch). The swap reached the success scene, and the saved order URI opened `https://explorer.rango.exchange/search?query=a3a23aa0-01cc-4868-b360-f7d2d4a66284`, where the query value is the Rango request ID rather than the destination address.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to swap `orderUri` strings with the same fallback as before when no tracking ID exists; no transaction or quote logic changes.
> 
> **Overview**
> **Rango swap explorer links** now use Rango’s tracking ID (`requestId`, `id`, `uuid`, or `transactionId`) in the saved `orderUri` for **every** chain path (Solana, Sui, Cosmos, EVM), not only Cosmos.
> 
> That logic is computed once before the transaction-type `switch`, so each branch sets `savedAction.orderUri` to `https://explorer.rango.exchange/search?query=<trackingId>`. If no ID is returned, behavior is unchanged: the URI still uses the destination address. A debug log records the chosen id and URI.
> 
> CHANGELOG documents the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80c9722fd377afb4efcf3d52289ddb3096ac943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->