### PR TITLE
Fix Maya CACAO source swaps (below min limit / Invalid publicAddress)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fixed: (Xgram) Map send and receive amounts correctly for reverse "to" quotes, which previously swapped them.
 - fixed: (Xgram) Prefer the CORS-capable fetch when available, and parse the create-order response body on non-OK HTTP status so limit, region, and unsupported-currency errors surface to the user instead of a generic failure.
 - fixed: (Xgram) Uppercase the Cardano network code to match the other network identifiers.
+- fixed: (Maya) CACAO source swaps (e.g. CACAO to BTC) no longer fail with "amount below min limit" / "Invalid publicAddress". Two issues are addressed: the native deposit path now matches the Maya chain by its real pluginId `mayachain` (it was checking a non-existent `cacao`), and Maya quote amounts now use each asset's native precision (CACAO is 1e10) instead of Thornode's universal 1e8, so amounts are no longer under-scaled 100x.
 
 ## 2.48.0 (2026-06-16)
 

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -43,6 +43,7 @@ import {
   fetchInfo,
   fetchWaterfall,
   getAddress,
+  getTokenMultiplier,
   makeQueryParams,
   nativeToDenomination,
   promiseWithTimeout,
@@ -60,6 +61,20 @@ export const EVM_SEND_GAS = '80000'
 export const EVM_TOKEN_SEND_GAS = '80000'
 export const THOR_LIMIT_UNITS = '100000000'
 export const AFFILIATE_FEE_BASIS_DEFAULT = '50'
+
+// Thornode normalizes every asset's amount to THOR_LIMIT_UNITS (1e8) in its
+// quote API. Mayanode instead expresses amounts in each asset's own native
+// precision (e.g. CACAO is 1e10, BTC is 1e8). Resolve the multiplier that
+// converts between an asset's exchange-denominated amount and the units the
+// node API expects for this swap.
+const getNodeLimitUnits = (
+  swapInfo: EdgeSwapInfo,
+  wallet: EdgeCurrencyWallet,
+  tokenId: EdgeTokenId
+): string =>
+  swapInfo.pluginId === 'mayaprotocol'
+    ? getTokenMultiplier(wallet, tokenId)
+    : THOR_LIMIT_UNITS
 const NATIVE_IN_GWEI = '1000000000'
 const STREAMING_INTERVAL_DEFAULT = 10
 const STREAMING_QUANTITY_DEFAULT = 10
@@ -768,7 +783,7 @@ export function makeThorchainBasedPlugin(
       memo = memo.replace(/^0x/, '')
     } else if (
       fromWallet.currencyInfo.pluginId === 'thorchainrune' ||
-      fromWallet.currencyInfo.pluginId === 'cacao'
+      fromWallet.currencyInfo.pluginId === 'mayachain'
     ) {
       const chainPrefix =
         fromWallet.currencyInfo.pluginId === 'thorchainrune' ? 'THOR' : 'MAYA'
@@ -778,7 +793,10 @@ export function makeThorchainBasedPlugin(
           {
             amount: fromNativeAmount,
             asset: `${chainPrefix}.${fromCurrencyCode}`,
-            decimals: THOR_LIMIT_UNITS
+            // The deposit amount is in the source asset's native precision, so
+            // tag it with that asset's multiplier. For RUNE this equals
+            // THOR_LIMIT_UNITS (1e8); CACAO needs its own 1e10 multiplier.
+            decimals: getTokenMultiplier(fromWallet, fromTokenId)
           }
         ],
         memo,
@@ -996,7 +1014,7 @@ export function makeThorchainBasedPlugin(
       if (
         quoteFor === 'max' &&
         (fromWallet.currencyInfo.pluginId === 'thorchainrune' ||
-          fromWallet.currencyInfo.pluginId === 'cacao') &&
+          fromWallet.currencyInfo.pluginId === 'mayachain') &&
         request.fromTokenId == null
       ) {
         // fetchSwapQuoteInner has unique logic to handle 'max' quotes but
@@ -1089,14 +1107,19 @@ const calcSwapFrom = async ({
   streamingInterval,
   streamingQuantity
 }: CalcSwapParams): Promise<CalcSwapResponse> => {
-  // Max quotes start with getting a quote for 10 RUNE
-  const fromNativeAmount =
-    quoteFor === 'max' &&
+  // Max quotes start by probing the rate with a small fixed amount that must
+  // clear the provider's minimum. 10 RUNE works for Thorchain; CACAO is lower
+  // value and 10-decimal, so probe with ~1000 CACAO to stay above Maya's min.
+  const isNativeDeposit =
     (fromWallet.currencyInfo.pluginId === 'thorchainrune' ||
-      fromWallet.currencyInfo.pluginId === 'cacao') &&
+      fromWallet.currencyInfo.pluginId === 'mayachain') &&
     fromTokenId == null
-      ? '1000000000'
-      : nativeAmount
+  const maxSeedAmount =
+    fromWallet.currencyInfo.pluginId === 'mayachain'
+      ? mul('1000', getTokenMultiplier(fromWallet, fromTokenId))
+      : '1000000000'
+  const fromNativeAmount =
+    quoteFor === 'max' && isNativeDeposit ? maxSeedAmount : nativeAmount
 
   // Get exchange rate from source to destination asset
   const fromExchangeAmount = nativeToDenomination(
@@ -1107,7 +1130,10 @@ const calcSwapFrom = async ({
 
   log(`fromExchangeAmount: ${fromExchangeAmount}`)
 
-  const fromThorAmountDecimal = mul(fromExchangeAmount, THOR_LIMIT_UNITS)
+  const fromLimitUnits = getNodeLimitUnits(swapInfo, fromWallet, fromTokenId)
+  const toLimitUnits = getNodeLimitUnits(swapInfo, toWallet, toTokenId)
+
+  const fromThorAmountDecimal = mul(fromExchangeAmount, fromLimitUnits)
   const fromThorAmount = round(fromThorAmountDecimal, 0)
 
   const noStreamParams = {
@@ -1164,7 +1190,7 @@ const calcSwapFrom = async ({
 
   log(`toThorAmountWithSpread = limit: ${toThorAmountWithSpread}`)
 
-  const toExchangeAmount = div18(toThorAmountWithSpread, THOR_LIMIT_UNITS)
+  const toExchangeAmount = div18(toThorAmountWithSpread, toLimitUnits)
   log(`toExchangeAmount: ${toExchangeAmount}`)
 
   const toNativeAmountFloat = denominationToNative(
@@ -1233,7 +1259,10 @@ const calcSwapTo = async ({
     toTokenId
   )
 
-  const requestedToThorAmount = mul(toExchangeAmount, THOR_LIMIT_UNITS)
+  const fromLimitUnits = getNodeLimitUnits(swapInfo, fromWallet, fromTokenId)
+  const toLimitUnits = getNodeLimitUnits(swapInfo, toWallet, toTokenId)
+
+  const requestedToThorAmount = mul(toExchangeAmount, toLimitUnits)
 
   log(`toExchangeAmount: ${toExchangeAmount}`)
 
@@ -1247,7 +1276,7 @@ const calcSwapTo = async ({
   )
 
   const requestedFromThorAmount = round(
-    mul(requestedFromExchangeAmount, THOR_LIMIT_UNITS),
+    mul(requestedFromExchangeAmount, fromLimitUnits),
     0
   )
 
@@ -1316,7 +1345,7 @@ const calcSwapTo = async ({
 
   log(`fromThorAmountWithSpread = limit: ${fromThorAmountWithSpread}`)
 
-  const fromExchangeAmount = div18(fromThorAmountWithSpread, THOR_LIMIT_UNITS)
+  const fromExchangeAmount = div18(fromThorAmountWithSpread, fromLimitUnits)
   log(`fromExchangeAmount: ${fromExchangeAmount}`)
 
   const fromNativeAmountFloat = denominationToNative(

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -299,7 +299,7 @@ export async function findMinimumSwapAmount({
   return lastWorkingAmount
 }
 
-function getTokenMultiplier(
+export function getTokenMultiplier(
   wallet: EdgeCurrencyWallet,
   tokenId: EdgeTokenId
 ): string {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Fixes Maya Protocol swaps from CACAO (e.g. CACAO → BTC), which failed at every amount with "amount is below the min limit" (and, at large amounts, an `Invalid publicAddress` core log). Maya CACAO → BTC works on the Maya website, so this was an Edge-side plugin bug.

There were two distinct root causes in the shared Thorchain/Maya plugin code (`src/swap/defi/thorchain/thorchainCommon.ts`):

1. **Wrong pluginId for the native deposit branch.** The RUNE/CACAO `MakeTxDeposit` path was gated on `fromWallet.currencyInfo.pluginId === 'cacao'`, but the Maya chain's pluginId is `mayachain` (`CACAO` is only the currency code, confirmed in `edge-currency-accountbased` `mayachainInfo.ts`). CACAO sources never matched the deposit branch, fell through to the UTXO path, left `publicAddress` null, and threw `Invalid publicAddress` once an amount cleared the (broken) min check. The GUI surfaces that thrown error as the generic "below min limit" message.

2. **Wrong amount precision for Mayanode quotes.** Mayanode expresses quote amounts in each asset's native precision (CACAO is 1e10, BTC is 1e8), whereas Thornode normalizes everything to `THOR_LIMIT_UNITS` (1e8). Using 1e8 for CACAO under-scaled the amount sent to Mayanode by 100×, so any normal amount came back below Maya's minimum. A new `getNodeLimitUnits` helper resolves the correct multiplier per asset for Maya (the asset's native multiplier) while leaving Thorchain on `THOR_LIMIT_UNITS`. The deposit coin `decimals` likewise now uses the source asset's native multiplier (a no-op for RUNE, since its native multiplier already equals 1e8).

Thorchain (RUNE) behavior is unchanged: for every RUNE/Thorchain asset the new helper resolves to the existing `THOR_LIMIT_UNITS`.

#### Testing

Verified end to end on the iOS simulator with the funded `edge-funds` MAYAChain wallet:

- `tsc` + eslint + jest (`verify-repo.sh`) pass.
- Before the fix, a CACAO → BTC swap returned "amount is below the min limit" at $15, $100, and MAX.
- After the fix, a 942.667 CACAO (~$100) → BTC quote resolves correctly (0.00156738 BTC, matching a direct Mayanode `/quote/swap` call) and the swap executes through the confirm slider to the "Congratulations! Your exchange is being processed!" success scene.

Screenshots attached below.

Asana: https://app.asana.com/0/1215088146871429/1215734647159265

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared quote and tx-building logic for all Maya swaps and max-quote paths; Thorchain is gated on pluginId but any Maya precision mistake could mis-quote or mis-build deposits.
> 
> **Overview**
> Fixes **Maya Protocol** swaps when **CACAO** is the source (e.g. CACAO → BTC), which previously failed with “below min limit” or `Invalid publicAddress`.
> 
> The shared Thorchain/Maya plugin now treats native CACAO/RUNE deposits with wallet pluginId **`mayachain`** instead of the non-existent **`cacao`**, so CACAO uses the **`MakeTxDeposit`** path instead of falling through to UTXO handling.
> 
> For **`mayaprotocol`** quotes, amounts sent to Mayanode and converted back use **`getNodeLimitUnits`** (per-asset native multipliers via exported **`getTokenMultiplier`**) instead of universal **`THOR_LIMIT_UNITS` (1e8)**—fixing ~100× under-scaling for CACAO (1e10). Deposit **`decimals`** and **max-quote** probe amounts follow the same multipliers (e.g. ~1000 CACAO for max seeds on Maya).
> 
> Thorchain/RUNE behavior is unchanged when the helper resolves to 1e8.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57b0489182873f18362f52a87e33cd69dfaa6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->