### PR TITLE
Fix EVM token swap pending metadata showing 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: Changelly swap provider
+- fixed: (Thorchain/Maya) Show the correct from-amount in pending swap transaction metadata for EVM token swaps (e.g. USDT to ETH) instead of 0.
 
 ## 2.49.0 (2026-07-11)
 

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -714,7 +714,6 @@ export function makeThorchainBasedPlugin(
     } = calcResponse
     let { memo } = calcResponse
 
-    let ethNativeAmount = fromNativeAmount
     let publicAddress = thorAddress
     const preTxs: EdgeTransaction[] = []
     let memoType: EdgeMemo['type']
@@ -758,9 +757,6 @@ export function makeThorchainBasedPlugin(
             `Missing sourceTokenContractAddress for ${fromMainnetCode}`
           )
         assetAddress = sourceTokenContractAddress
-
-        // Token transactions send no ETH (or other EVM mainnet coin)
-        ethNativeAmount = '0'
 
         const approvalTxs = await createEvmApprovalEdgeTransactions({
           request,
@@ -920,7 +916,13 @@ export function makeThorchainBasedPlugin(
       ],
       spendTargets: [
         {
-          nativeAmount: ethNativeAmount,
+          // The amount spent from the wallet, always denominated in the
+          // from-asset. For EVM token swaps this is the token amount even though
+          // the router contract call sends zero parent-currency value (the
+          // currency engine forces value to 0 for token contract calls). Using
+          // the token amount here keeps the pending transaction metadata
+          // (amount, fiat, percent) correct instead of showing 0.
+          nativeAmount: fromNativeAmount,
           publicAddress
         }
       ],


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/0/1215088146871429/1211543001846210

Fixes a Maya/Thorchain bug where swapping an EVM ERC20 token (e.g. USDT on Ethereum) to a native asset showed 0 for the value (coins, USD, percentage) in the transaction metadata while the swap was pending.

Root cause: in `makeThorchainBasedPlugin` (`src/swap/defi/thorchain/thorchainCommon.ts`), EVM token swaps set the spend target `nativeAmount` to `0` (it reused the `ethNativeAmount` value, which is the parent-currency tx `value` and is 0 for token contract calls). The currency engine derives the pending `EdgeTransaction.nativeAmount` from `spendTarget.nativeAmount`, so the token swap recorded 0 and the pending-transaction metadata rendered 0. Once the tx mined, the engine re-read the real on-chain token amount, which is why only the pending state was wrong.

Fix: set the spend target `nativeAmount` to `fromNativeAmount` (the token amount being spent). The broadcast transaction is unchanged: for an EVM token contract call the engine sends the router `depositWithExpiry` calldata and forces the tx `value` to 0 regardless of `spendTarget.nativeAmount` (`getTxParameterInformation` returns `value: undefined` and `signTx` hard-sets `txValue = 0x00` for token contract calls), so `spendTarget.nativeAmount` only drives the displayed amount and the balance check. Native EVM, RUNE/CACAO, ZEC and UTXO paths already passed `fromNativeAmount`, so this is a no-op for them.

Applies to both Maya and Thorchain since they share this code.

### Testing

- `tsc --noEmit`, eslint, and the jest suite pass (verify-repo).
- Built into edge-react-gui (iOS sim, edge-funds account) and drove the real swap: forced Maya/Thorchain as the only enabled providers, obtained a live Maya Protocol quote for USDT (Ethereum) to BTC, and confirmed (slider) so the patched quote-construction path ran. Execution timed out at Maya's network "Locating a swap" step (60s) before the deposit broadcast, so the pending-transaction metadata could not be captured; no funds moved. Screenshot below shows the patched Maya path producing the token-swap quote in-app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change in shared Thorchain/Maya quote construction; on-chain EVM token deposit behavior is unchanged per the PR description.
> 
> **Overview**
> Fixes **Thorchain/Maya** swaps where pending transaction UI showed **0** for the send amount (coins, fiat, %) when swapping an **EVM ERC-20** (e.g. USDT on Ethereum) to another asset.
> 
> In `thorchainCommon.ts`, the EVM spend target no longer forces `nativeAmount` to **0** for token deposits. It always uses **`fromNativeAmount`** (the token amount being spent). On-chain behavior is unchanged: token router calls still broadcast with zero parent-currency `value`; this field only drives pending metadata and balance checks. Native EVM and non-EVM paths were already correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db1fcfe248d4e7a1360ddd976d2bb309b5bbca6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->