### PR TITLE
Fix swap plugin support email domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Correct the support email (support@edge.com → support@edge.app) for the Bridgeless, Cosmos IBC, Fantom/Sonic Upgrade, and Transfer swap plugins.
+
 ## 2.48.1 (2026-06-23)
 
 - fixed: (Xgram) Map send and receive amounts correctly for reverse "to" quotes, which previously swapped them.

--- a/src/swap/defi/bridgeless.ts
+++ b/src/swap/defi/bridgeless.ts
@@ -44,7 +44,7 @@ const swapInfo: EdgeSwapInfo = {
   pluginId,
   displayName: 'Bridgeless',
   isDex: true,
-  supportEmail: 'support@edge.com'
+  supportEmail: 'support@edge.app'
 }
 
 const BASE_URL = 'https://rpc-api.node0.mainnet.bridgeless.com'

--- a/src/swap/defi/cosmosIbc.ts
+++ b/src/swap/defi/cosmosIbc.ts
@@ -22,7 +22,7 @@ const swapInfo: EdgeSwapInfo = {
   displayName: 'Cosmos IBC',
   orderUri: undefined,
   isDex: true,
-  supportEmail: 'support@edge.com'
+  supportEmail: 'support@edge.app'
 }
 
 export function makeCosmosIbcPlugin(

--- a/src/swap/defi/fantomSonicUpgrade.ts
+++ b/src/swap/defi/fantomSonicUpgrade.ts
@@ -34,7 +34,7 @@ const swapInfo: EdgeSwapInfo = {
   displayName: 'Fantom/Sonic Upgrade',
   isDex: true,
   orderUri: undefined,
-  supportEmail: 'support@edge.com'
+  supportEmail: 'support@edge.app'
 }
 
 export function makeFantomSonicUpgradePlugin(

--- a/src/swap/transfer.ts
+++ b/src/swap/transfer.ts
@@ -22,7 +22,7 @@ const swapInfo: EdgeSwapInfo = {
   pluginId,
   displayName: 'Transfer',
   orderUri: undefined,
-  supportEmail: 'support@edge.com'
+  supportEmail: 'support@edge.app'
 }
 
 export function makeTransferPlugin(


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary -->

Four Edge-owned swap plugins hardcoded their support contact as `support@edge.com`, which is not an Edge support domain. As a result, affected DEX swaps showed the wrong support email in transaction details (e.g. BTC→BTCx via Bridgeless). This corrects them to `support@edge.app`, matching the other Edge swap plugins that already use that address.

Plugins changed (each `swapInfo.supportEmail` only):
- Bridgeless — `src/swap/defi/bridgeless.ts`
- Cosmos IBC — `src/swap/defi/cosmosIbc.ts`
- Fantom/Sonic Upgrade — `src/swap/defi/fantomSonicUpgrade.ts`
- Transfer — `src/swap/transfer.ts`

Third-party exchange support emails (Sideshift, ChangeNOW, Exolix, etc.) were intentionally left unchanged.

Asana: https://app.asana.com/1/9976422036640/project/1213843652804305/task/1216003006917320

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only email string changes with no swap, auth, or transaction logic touched.
> 
> **Overview**
> Updates **`supportEmail`** on four swap plugins from `support@edge.com` to **`support@edge.app`** so in-app support links and swap metadata point at the correct Edge address.
> 
> Affected plugins: **Bridgeless**, **Cosmos IBC**, **Fantom/Sonic Upgrade**, and **Transfer** (each `swapInfo` only). The **Unreleased** **CHANGELOG** entry documents the same fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43947d65b1d331890dd4f0e4f2c413b3f067cf5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->