### PR TITLE
Fall back to float-rate quotes when Xgram rejects fixed-rate orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Xgram) Fall back to a float-rate estimate quote when the provider rejects fixed-rate order creation, which currently blocks all Xgram quotes.
+
 ## 2.48.2 (2026-06-29)
 
 - fixed: Correct the support email (support@edge.com → support@edge.app) for the Bridgeless, Cosmos IBC, Fantom/Sonic Upgrade, and Transfer swap plugins.

--- a/src/swap/central/xgram.ts
+++ b/src/swap/central/xgram.ts
@@ -70,8 +70,14 @@ const addressTypeMap: StringMap = {
   zcash: 'transparentAddress'
 }
 
-const swapType = 'fixed' as const
+type XgramRateType = 'fixed' | 'float'
 const ccyAmountLimitRegex = /ccyAmount must be ([><])\s*([\d.]+)/
+
+const isTypedSwapError = (error: unknown): boolean =>
+  error instanceof SwapAboveLimitError ||
+  error instanceof SwapBelowLimitError ||
+  error instanceof SwapCurrencyError ||
+  error instanceof SwapPermissionError
 
 export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
   const { io } = opts
@@ -120,7 +126,8 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
 
     async function createOrder(
       isSelling: boolean,
-      largeDenomAmount: string
+      largeDenomAmount: string,
+      rateType: XgramRateType
     ): Promise<XgramResponse> {
       const createExchangeUrl = isSelling ? newExchange : newRevExchange
 
@@ -128,7 +135,7 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         toAddress: String(toAddress),
         refundAddress: String(fromAddress),
         ccyAmount: largeDenomAmount,
-        type: swapType,
+        type: rateType,
         fromContractAddress: fromContractAddress ?? '',
         toContractAddress: toContractAddress ?? '',
         fromNetwork,
@@ -245,6 +252,21 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         isSelling ? request.fromTokenId : request.toTokenId
       )
 
+      // Xgram intermittently rejects every fixed-rate creation provider-side
+      // with a generic "Error while creating exchange", so fall back to a
+      // float-rate order when the fixed-rate attempt fails. Typed swap errors
+      // (limits, unsupported pair, geo restriction) apply to both rate types
+      // and are rethrown without a retry. Float orders lock no rate, so the
+      // resulting quote is flagged as an estimate.
+      let order: XgramResponse
+      let isEstimate = false
+      try {
+        order = await createOrder(isSelling, largeDenomAmount, 'fixed')
+      } catch (error: unknown) {
+        if (isTypedSwapError(error)) throw error
+        order = await createOrder(isSelling, largeDenomAmount, 'float')
+        isEstimate = true
+      }
       const {
         fromAmount,
         toAmount,
@@ -252,7 +274,7 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         payinExtraId,
         id,
         validUntil
-      } = await createOrder(isSelling, largeDenomAmount)
+      } = order
 
       const fromNativeAmount = denominationToNative(
         request.fromWallet,
@@ -293,7 +315,7 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
           swapInfo,
           orderId: id,
           orderUri: orderUri + id,
-          isEstimate: false,
+          isEstimate,
           toAsset: {
             pluginId: request.toWallet.currencyInfo.pluginId,
             tokenId: request.toTokenId,


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216219577215536/f)

Fixes the "no Xgram quotes on any pair" failures reported on staging 26063001 (Asana: https://app.asana.com/1/9976422036640/project/1215088146871429/task/1216219577215536).

Debugging directly against the Xgram partner API showed two independent provider-side conditions:

1. Fixed-rate order creation is currently broken for every pair. `type=fixed` returns a generic `{"result":false,"error":"Error while creating exchange"}` on both the forward (`launch-new-exchange-edge`) and reverse (`launch-new-payment-exchange-edge`) endpoints, even for enabled pairs with valid addresses. The plugin hardcoded `type=fixed`, so the app got zero Xgram quotes. The same requests with `type=float` succeed immediately.
2. Separately, Xgram has disabled all non-XMR pairs for Edge's partner key (`CURRENCY_UNSUPPORTED` / "Pair is disabled" regardless of rate type; ETH->XMR included). Currently enabled: BTC/LTC/BCH/TRX/SOL <-> XMR. This is not code-fixable and needs a provider/BD follow-up with Xgram.

This PR fixes (1): try the fixed-rate order first, and when it fails with an untyped error, retry once as a float-rate order and flag the resulting quote `isEstimate: true` (same pattern as changenow's standard flow). Typed limit / unsupported-pair / geo-restriction errors still throw immediately without a retry. When Xgram restores fixed-rate support, the plugin automatically returns to fixed quotes.

Verified in-app on the iOS sim with the modified plugin linked and Xgram forced as the sole provider: SOL->XMR quoted through the float fallback (with the Estimated Quote warning) and the swap executed to the "Congratulations" success scene. Screenshots attached below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Xgram order creation and quote metadata for all pairs; behavior is scoped to one CEX plugin but directly affects which quotes users see and whether rates are marked estimated.
> 
> **Overview**
> Restores Xgram quoting when the provider rejects **fixed-rate** order creation by trying `type=fixed` first, then retrying once with `type=float` on generic failures.
> 
> `createOrder` now takes a **`fixed` | `float`** rate type instead of always sending fixed. **Limit, unsupported pair, and geo errors** still fail immediately (no float retry). Successful float fallbacks set **`isEstimate: true`** on swap metadata so the UI can show an estimated quote.
> 
> CHANGELOG updated for the Unreleased section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbafdfe5daca2f4eb0fed8ecdc806af52eba1a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->