### PR TITLE
Buffer swap provider gas prices to avoid below-minimum race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (LI.FI, Rango, Unizen) Apply a 5% buffer to the swap provider's quoted gas price so swaps aren't rejected with a "Gas price below minimum" error when the network base fee rises between quote and signing.
+
 ## 2.50.0 (2026-07-13)
 
 - added: Changelly swap provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "typescript": "~4.9.5",
         "url": "^0.11.3",
         "webpack": "^5.104.1",
-        "webpack-cli": "^4.6.0",
+        "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.4"
       }
     },
@@ -6576,34 +6576,45 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-      "integrity": "sha1-eyDOHBJTORLDshfqaCYjZfoppvU= sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x",
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
-      "integrity": "sha1-bHjBPFh0hS1uLdF/CKQfP+TCYbE= sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
       "dev": true,
-      "dependencies": {
-        "envinfo": "^7.7.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-      "integrity": "sha1-4Zk2iaxC0rFukZQ3bPtnU/YlTbE= sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       },
       "peerDependenciesMeta": {
         "webpack-dev-server": {
@@ -11089,10 +11100,11 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.10.0.tgz",
-      "integrity": "sha1-VRRuOQnMX+Y8Itpj+xWwWurDWxM= sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.21.0.tgz",
+      "integrity": "sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "envinfo": "dist/cli.js"
       },
@@ -14255,12 +14267,13 @@
       }
     },
     "node_modules/interpret": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
-      "integrity": "sha1-GnigtZZcQKVBbQB61vUK0nxBffk= sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -17928,15 +17941,16 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-      "integrity": "sha1-lHipahyhNbXoj8An8D7pLWxkVoY= sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/redux": {
@@ -21650,42 +21664,41 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
-      "integrity": "sha1-N8HWnI2FIUxaZeWJN49TrsZNqzE= sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.2.0",
-        "@webpack-cli/info": "^1.5.0",
-        "@webpack-cli/serve": "^1.7.0",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
         "colorette": "^2.0.14",
-        "commander": "^7.0.0",
+        "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",
+        "envinfo": "^7.7.3",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
-        "interpret": "^2.2.0",
-        "rechoir": "^0.7.0",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
         "webpack-merge": "^5.7.3"
       },
       "bin": {
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x"
+        "webpack": "5.x.x"
       },
       "peerDependenciesMeta": {
         "@webpack-cli/generators": {
-          "optional": true
-        },
-        "@webpack-cli/migrate": {
           "optional": true
         },
         "webpack-bundle-analyzer": {
@@ -21697,12 +21710,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc= sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=14"
       }
     },
     "node_modules/webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "typescript": "~4.9.5",
     "url": "^0.11.3",
     "webpack": "^5.104.1",
-    "webpack-cli": "^4.6.0",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.4"
   },
   "overrides": {

--- a/src/swap/defi/defiUtils.ts
+++ b/src/swap/defi/defiUtils.ts
@@ -1,3 +1,4 @@
+import { div, mul, round } from 'biggystring'
 import { asMaybe, asObject, asString } from 'cleaners'
 import {
   EdgeCurrencyConfig,
@@ -233,3 +234,30 @@ export const getDepositWithExpiryData = async (params: {
 }
 
 export const WEI_MULTIPLIER = '1000000000'
+
+export const SWAP_GAS_PRICE_BUFFER_MULTIPLIER = '1.05'
+
+/**
+ * Swap providers quote a gas price at quote time, but the network base fee can
+ * rise before we sign the transaction, causing it to be rejected as below the
+ * network minimum (`Gas price X wei below minimum Y wei`). Apply a small buffer
+ * to the provider-supplied gas price to absorb that drift.
+ *
+ * The buffer is applied in wei and rounded to an integer wei value, so the
+ * returned gwei string never carries more than 9 decimal places. The engine
+ * multiplies `customNetworkFee.gasPrice` back to wei, and a fractional wei
+ * amount corrupts the transaction's hex encoding.
+ *
+ * Note the buffer is real spend, not free headroom: the engine derives the
+ * EIP-1559 tip as `maxFeePerGas - baseFee`, so the entire buffered value is
+ * paid. Keep the multiplier modest.
+ *
+ * @param gasPriceWei provider-quoted gas price, in wei
+ * @returns buffered gas price, in gwei
+ */
+export const bufferSwapGasPrice = (gasPriceWei: string): string =>
+  div(
+    round(mul(gasPriceWei, SWAP_GAS_PRICE_BUFFER_MULTIPLIER), 0),
+    WEI_MULTIPLIER,
+    18
+  )

--- a/src/swap/defi/lifi.ts
+++ b/src/swap/defi/lifi.ts
@@ -45,7 +45,10 @@ import {
   MakeTxParams,
   StringMap
 } from '../types'
-import { createEvmApprovalEdgeTransactions, WEI_MULTIPLIER } from './defiUtils'
+import {
+  bufferSwapGasPrice,
+  createEvmApprovalEdgeTransactions
+} from './defiUtils'
 
 const pluginId = 'lifi'
 const swapInfo: EdgeSwapInfo = {
@@ -448,7 +451,7 @@ export function makeLifiPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         const transactionRequest = asTransactionRequest(transactionRequestRaw)
         const { data, gasLimit, gasPrice } = transactionRequest
         const gasPriceDecimal = hexToDecimal(gasPrice)
-        const gasPriceGwei = div18(gasPriceDecimal, WEI_MULTIPLIER)
+        const gasPriceGwei = bufferSwapGasPrice(gasPriceDecimal)
 
         if (sendingToken) {
           const approvalTxs = await createEvmApprovalEdgeTransactions({

--- a/src/swap/defi/rango.ts
+++ b/src/swap/defi/rango.ts
@@ -25,7 +25,6 @@ import {
 import { base64 } from 'rfc4648'
 
 import { rango as rangoMapping } from '../../mappings/rango'
-import { div18 } from '../../util/biggystringplus'
 import {
   getMaxSwappable,
   makeSwapPluginQuote,
@@ -50,9 +49,9 @@ import {
   StringMap
 } from '../types'
 import {
+  bufferSwapGasPrice,
   createEvmApprovalEdgeTransactions,
-  decodeEvmApprovalData,
-  WEI_MULTIPLIER
+  decodeEvmApprovalData
 } from './defiUtils'
 
 const swapInfo: EdgeSwapInfo = {
@@ -739,7 +738,7 @@ export function makeRangoPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
               : undefined,
           gasPrice:
             evmTransaction.gasPrice != null
-              ? div18(evmTransaction.gasPrice, WEI_MULTIPLIER)
+              ? bufferSwapGasPrice(evmTransaction.gasPrice)
               : undefined,
           maxFeePerGas: evmTransaction.maxFeePerGas ?? undefined,
           maxPriorityFeePerGas: evmTransaction.maxPriorityFeePerGas ?? undefined

--- a/src/swap/defi/unizen.ts
+++ b/src/swap/defi/unizen.ts
@@ -1,5 +1,5 @@
 import contracts from '@unizen-io/unizen-contract-addresses/production.json'
-import { div } from 'biggystring'
+import { mul } from 'biggystring'
 import {
   asArray,
   asMaybe,
@@ -31,7 +31,11 @@ import {
 import { convertRequest, getAddress } from '../../util/utils'
 import { EdgeSwapRequestPlugin, StringMap } from '../types'
 import { getTokenAddress } from './0x/util'
-import { createEvmApprovalEdgeTransactions, WEI_MULTIPLIER } from './defiUtils'
+import {
+  bufferSwapGasPrice,
+  createEvmApprovalEdgeTransactions,
+  WEI_MULTIPLIER
+} from './defiUtils'
 
 const pluginId = 'unizen'
 const swapInfo: EdgeSwapInfo = {
@@ -62,10 +66,10 @@ interface QuoteSpendParams extends SwapNetworkFees {
 }
 
 const makeEvmFees = (rate: string, units: string = 'wei'): SwapNetworkFees => {
-  const multiplier = units === 'wei' ? WEI_MULTIPLIER : 1
+  const rateWei = units === 'wei' ? rate : mul(rate, WEI_MULTIPLIER)
   return {
     customNetworkFee: {
-      gasPrice: div(rate, multiplier)
+      gasPrice: bufferSwapGasPrice(rateWei)
     },
     networkFeeOption: 'custom'
   }

--- a/test/unizen.test.ts
+++ b/test/unizen.test.ts
@@ -87,7 +87,7 @@ describe(`unizen makeSpendParams`, function () {
     )
 
     assert.deepEqual(spendParams, {
-      customNetworkFee: { gasPrice: '1' },
+      customNetworkFee: { gasPrice: '1.05' },
       networkFeeOption: 'custom',
       destinationAddress: '0x880E0cE34F48c0cbC68BF3E745F17175BA8c650e',
       expirationDate: new Date('2024-12-20T22:36:28.000Z'),
@@ -114,7 +114,7 @@ describe(`unizen makeSpendParams`, function () {
     )
 
     assert.deepEqual(spendParams, {
-      customNetworkFee: { gasPrice: '7' },
+      customNetworkFee: { gasPrice: '8.224647235' },
       networkFeeOption: 'custom',
       destinationAddress: '0xBE2A77399Cde40EfbBc4e89207332c4a4079c83D',
       expirationDate: new Date('2024-12-20T22:38:57.000Z'),
@@ -168,7 +168,7 @@ describe(`unizen makeSpendParams`, function () {
     )
 
     assert.deepEqual(spendParams, {
-      customNetworkFee: { gasPrice: '1' },
+      customNetworkFee: { gasPrice: '1.05' },
       networkFeeOption: 'custom',
       destinationAddress: '0xf12f7b4238e85322b1b2362122d333c96851c223',
       expirationDate: new Date('2024-12-20T02:06:13.000Z'),


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Swap partners (LI.FI, Rango, Unizen) return a gas price alongside their quote, which we pass straight through as a `customNetworkFee.gasPrice`. There's a race between that quote and when the engine actually signs the transaction: the account-based engine clamps the minimum acceptable gas price to the **current network base fee**, and on fast-moving chains the base fee can tick up in the gap. When it does, the provider's now-stale gas price lands below that floor and the send is rejected — e.g. on Arbitrum:

> Gas price 20084000 wei below minimum 20208000 wei

To give the quoted price enough headroom to clear the floor, apply a small **5% buffer** to the provider-supplied gas price via a shared `bufferSwapGasPrice` helper in `defiUtils.ts`, used at each provider's gas-price conversion point (LI.FI, Rango, Unizen).

Notes:
- The buffer is modest on purpose. The engine derives the EIP-1559 tip as `maxFeePerGas - baseFee`, so the buffered value is actually spent rather than being free ceiling headroom.
- Rango's EIP-1559 `maxFeePerGas` / `maxPriorityFeePerGas` path is left untouched — only the legacy `gasPrice` field (the one that hits the floor check) is buffered.
- Unizen unit-test fixtures updated to the buffered gas prices.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real network fees on EVM DEX swaps (users pay the buffered gas), but scope is limited to fee calculation on three providers with a modest multiplier.
> 
> **Overview**
> Adds shared **`bufferSwapGasPrice`** in `defiUtils.ts` that bumps provider-quoted gas (in wei) by **5%**, rounds to integer wei, then returns gwei so `customNetworkFee.gasPrice` stays above the network minimum when base fee moves between quote and sign.
> 
> **LI.FI**, **Rango** (legacy `gasPrice` only; EIP-1559 `maxFeePerGas` / `maxPriorityFeePerGas` unchanged), and **Unizen** now use this helper instead of passing the raw quoted rate. Unizen **`makeEvmFees`** normalizes gwei inputs to wei before buffering.
> 
> Also bumps **`webpack-cli`** from ^4.6.0 to ^5.1.4 (lockfile) and updates Unizen unit-test expected gas prices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69c135ebcf7ce0806214a5279b76f1e46c7a548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216067423670379