### PR TITLE
Bridgeless: optional referral id in all deposit payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- added: (Bridgeless) Optional `referralId` init option, included in EVM, Zano, and Bitcoin/BCH deposit payloads to attribute referral revenue.
+- changed: (Bridgeless) Bitcoin/BCH deposits now encode the destination using the documented bridge memo format (chain id, referral id, and Base58-encoded receiver).
+- fixed: (Bridgeless) Quoted amounts now include the referral's additional commission (fetched from the bridge's referral registry) when a referral id is configured.
 - fixed: (LI.FI, Rango, Unizen) Apply a 5% buffer to the swap provider's quoted gas price so swaps aren't rejected with a "Gas price below minimum" error when the network base fee rises between quote and signing.
 
 ## 2.50.0 (2026-07-13)

--- a/src/swap/defi/bridgeless.ts
+++ b/src/swap/defi/bridgeless.ts
@@ -7,6 +7,7 @@ import {
   asNull,
   asNumber,
   asObject,
+  asOptional,
   asString
 } from 'cleaners'
 import {
@@ -53,7 +54,7 @@ const AUTO_BOT_URL = 'https://autobot-wusa1.edge.app'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const EDGE_PLUGINID_CHAINID_MAP: Record<string, string> = {
-  // base: '8453', // no swaps available on zano yet
+  // base: '8453', // disabled: its only bridgeable asset (wrapped BTC) has no activity on Base yet
   binancesmartchain: '56',
   bitcoin: '0',
   bitcoincash: '5',
@@ -103,6 +104,17 @@ const asBridgeChain = asObject({
 const asBridgeTokens = asObject({
   tokens: asArray(asToken),
   pagination: asPagination
+})
+
+const asReferral = asObject({
+  referral: asObject({
+    commission_rate: asString
+  })
+})
+
+const asInitOptions = asObject({
+  // Bridgeless referral id (uint16). When omitted, deposits carry no referral.
+  referralId: asOptional(asNumber)
 })
 
 const fetchBridgeless = async (
@@ -161,33 +173,42 @@ interface MakeBridgelessEvmSpendInfoParams {
   fromTokenInfo: BridgelessTokenInfo
   toChainId: string
   receiver: string
+  referralId: number
 }
 
 const makeBridgelessEvmSpendInfo = ({
   fromAmount,
   fromTokenInfo,
   toChainId,
-  receiver
+  receiver,
+  referralId
 }: MakeBridgelessEvmSpendInfoParams): string => {
   const iface = new ethers.utils.Interface(BRIDGELESS_EVM_ABI)
   const tokenAddress = ethers.utils.getAddress(fromTokenInfo.address)
   const isNativeToken = tokenAddress.toLowerCase() === ZERO_ADDRESS
 
   return isNativeToken
-    ? iface.encodeFunctionData('depositNative', [receiver, toChainId, 0])
+    ? iface.encodeFunctionData('depositNative', [
+        receiver,
+        toChainId,
+        referralId
+      ])
     : iface.encodeFunctionData('depositERC20', [
         tokenAddress,
         fromAmount,
         receiver,
         toChainId,
         fromTokenInfo.is_wrapped,
-        0
+        referralId
       ])
 }
 
 export function makeBridgelessPlugin(
   opts: EdgeCorePluginOptions
 ): EdgeSwapPlugin {
+  // Referral id (uint16) applied to every deposit type. 0 means no referral.
+  const referralId = asInitOptions(opts.initOptions ?? {}).referralId ?? 0
+
   const fetchSwapQuoteInner = async (
     request: EdgeSwapRequestPlugin
   ): Promise<SwapOrder> => {
@@ -302,6 +323,20 @@ export function makeBridgelessPlugin(
     const fromDecimals = parseInt(fromTokenInfo.decimals, 10)
     const toDecimals = parseInt(toTokenInfo.decimals, 10)
 
+    // A registered referral id adds its own commission on top of the token's
+    // bridge commission, so include it in the quoted amounts.
+    let commissionRate = toTokenInfo.commission_rate
+    if (referralId !== 0) {
+      const referralRaw = await fetchBridgeless(
+        opts.io.fetch,
+        `/referrals/${referralId}`
+      )
+      commissionRate = add(
+        commissionRate,
+        asReferral(referralRaw).referral.commission_rate
+      )
+    }
+
     // The minimum amount is enforced by the amount of toToken received
     let fromAmount: string
     let toAmount: string
@@ -316,10 +351,7 @@ export function makeBridgelessPlugin(
         )
       }
 
-      const grossToAmount = ceil(
-        mul(toAmount, add('1', toTokenInfo.commission_rate)),
-        0
-      )
+      const grossToAmount = ceil(mul(toAmount, add('1', commissionRate)), 0)
       fromAmount = scaleNativeAmount(
         grossToAmount,
         toDecimals,
@@ -334,16 +366,10 @@ export function makeBridgelessPlugin(
         toDecimals,
         'down'
       )
-      toAmount = ceil(
-        mul(bridgedToAmount, sub('1', toTokenInfo.commission_rate)),
-        0
-      )
+      toAmount = ceil(mul(bridgedToAmount, sub('1', commissionRate)), 0)
 
       const minGrossToAmount = ceil(
-        mul(
-          toTokenInfo.min_withdrawal_amount,
-          add('1', toTokenInfo.commission_rate)
-        ),
+        mul(toTokenInfo.min_withdrawal_amount, add('1', commissionRate)),
         0
       )
       const minFromAmount = scaleNativeAmount(
@@ -388,14 +414,21 @@ export function makeBridgelessPlugin(
     switch (request.fromWallet.currencyInfo.pluginId) {
       case 'bitcoin':
       case 'bitcoincash': {
-        const receiver =
-          request.toWallet.currencyInfo.pluginId === 'zano'
-            ? base16.encode(base58.decode(toAddress))
-            : toAddress
-        const opReturn = `${receiver}${Buffer.from(
-          `#${toChainId}`,
-          'utf8'
-        ).toString('hex')}`
+        // Bridgeless BTC/BCH deposit memo (documented format):
+        //   [len(chainId)][chainId][referralId uint16 BE][addrEncByte][addrBytes]
+        // Bitcoin/BCH deposits only ever bridge to Zano here, so the address
+        // encoding byte is 0x04 (Base58) and the address bytes are the decoded
+        // Zano receiver address.
+        const chainIdBytes = Buffer.from(toChainId, 'utf8')
+        const referralBuf = Buffer.alloc(2)
+        referralBuf.writeUInt16BE(referralId)
+        const opReturn = Buffer.concat([
+          Buffer.from([chainIdBytes.length]),
+          chainIdBytes,
+          referralBuf,
+          Buffer.from([0x04]),
+          Buffer.from(base58.decode(toAddress))
+        ]).toString('hex')
 
         const spendInfo: EdgeSpendInfo = {
           otherParams: {
@@ -427,7 +460,8 @@ export function makeBridgelessPlugin(
           fromAmount,
           fromTokenInfo,
           toChainId,
-          receiver: toAddress
+          receiver: toAddress,
+          referralId
         })
         const isNativeToken =
           request.fromTokenId == null ||
@@ -469,9 +503,12 @@ export function makeBridgelessPlugin(
         }
       }
       case 'zano': {
+        // Only include referral_id when a referral is configured, keeping the
+        // no-referral burn body byte-identical to the previous format.
         const bodyData = {
           dst_add: toAddress,
           dst_net_id: toChainId,
+          ...(referralId !== 0 ? { referral_id: referralId } : {}),
           uniform_padding: '    '
         }
         const jsonString: string = JSON.stringify(bodyData)


### PR DESCRIPTION
Adds referral-revenue support to the Bridgeless swap plugin via an optional `referralId` init option (uint16; omitted ⇒ 0 ⇒ no referral, per the bridge spec):

- **EVM** (`depositNative`/`depositERC20`): the ABI's existing `uint16 referralId_` argument is now populated (was hardcoded 0).
- **Zano**: `referral_id` included in the burn `serviceEntries` body.
- **Bitcoin/BCH**: deposits migrate to the documented bridge memo format — `[len(chainId)][chainId][referralId u16 BE][0x04][base58-decoded receiver]` — which is the only format with a referral slot. Bridgeless team confirmed both formats are accepted and the documented one is required when a referral id is present.
- **Quotes include the referral commission**: a registered referral id charges its own `commission_rate` (from `/cosmos/bridge/referrals/{id}`) on top of the token's bridge commission, so quoted receive-amounts fetch and apply the combined rate when a referral id is configured.

The referral id arrives via `initOptions` from the GUI (`BRIDGELESS_INIT`, see EdgeApp/edge-react-gui#6072). With no referral id configured, EVM and Zano payloads are byte-identical to today.

**Testing**: BTC/BCH memo byte-verified against the documented example; live E2E BCH→Zano swap through the new memo format credited on Zano (first documented-format UTXO deposit on the wire).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-chain deposit encoding (especially BTC/BCH memo) and quote math; wrong memo or commission could mis-route deposits or mis-quote users, though no-referral EVM/Zano paths are preserved.
> 
> **Overview**
> Adds optional **`referralId`** plugin init (uint16; default **0** = no referral) so Bridgeless deposits can attribute referral revenue.
> 
> **Deposit payloads** now carry the id where the bridge supports it: EVM `depositNative`/`depositERC20` use the ABI referral argument (was always **0**); Zano burn JSON adds **`referral_id`** only when non-zero; Bitcoin/BCH OP_RETURN switches to the **documented memo layout** (chain id length + chain id + referral u16 BE + `0x04` + Base58-decoded Zano receiver) instead of the prior receiver + `#chainId` hex suffix.
> 
> **Quotes** fetch `/referrals/{id}` when a referral is set and apply **token bridge commission + referral commission** in from/to amount math (min-limit paths use the same combined rate). With no referral, EVM and Zano encoding stays byte-identical to before; BTC/BCH memo format still changes (includes referral slot as zero when id is 0).
> 
> CHANGELOG documents the feature; Base chain mapping comment is clarified as disabled due to low wrapped-BTC activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d46b1d2040945cdf84c0858ca4ed1bdba377260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216504872021055