### PR TITLE
Bridgeless: Solana and TON swaps to and from Zano

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - added: (Bridgeless) Solana (native SOL) and TON (native) swaps to and from Zano, including referral id support.
 - fixed: (Bridgeless) A configured referral id no longer inflates the quoted commission. The referral reward is paid out of the bridge's fixed commission, so quotes always use the token's commission rate.
+- fixed: Max swaps for custom-transaction (makeTx) flows now use the engine-reported spendable maximum instead of the full balance, which overshot by the network fee.
 
 ## 2.51.1 (2026-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- added: (Bridgeless) Solana (native SOL) and TON (native) swaps to and from Zano, including referral id support.
 - fixed: (Bridgeless) A configured referral id no longer inflates the quoted commission. The referral reward is paid out of the bridge's fixed commission, so quotes always use the token's commission rate.
 
 ## 2.51.1 (2026-07-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Bridgeless) A configured referral id no longer inflates the quoted commission. The referral reward is paid out of the bridge's fixed commission, so quotes always use the token's commission rate.
+
 ## 2.51.1 (2026-07-16)
 
 - fixed: (Maya) Quote amounts for assets bridged from other chains are no longer scaled by the asset's own precision, which gave wrong estimates and metadata (a Dash to USDT quote was overestimated 100x).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@cosmjs/encoding": "^0.32.2",
         "@scure/base": "^1.2.6",
+        "@ton/core": "0.59.1",
         "@unizen-io/unizen-contract-addresses": "^0.0.15",
         "biggystring": "^4.2.3",
         "cleaners": "^0.3.13",
@@ -5636,6 +5637,18 @@
         "bs58": "^5.0.0"
       }
     },
+    "node_modules/@ton/core": {
+      "version": "0.59.1",
+      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.59.1.tgz",
+      "integrity": "sha512-SxFBAvutYJaIllTkv82vbHTJhJI6NxzqUhi499CDEjJEZ9i6i9lHJiK2df4dlLAb/4SiWX6+QUzESkK4DEdnCw==",
+      "license": "MIT",
+      "dependencies": {
+        "symbol.inspect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@ton/crypto": ">=3.2.0"
+      }
+    },
     "node_modules/@ton/crypto": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
@@ -10808,19 +10821,6 @@
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "node_modules/edge-currency-accountbased/node_modules/@ton/core": {
-      "version": "0.59.1",
-      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.59.1.tgz",
-      "integrity": "sha512-SxFBAvutYJaIllTkv82vbHTJhJI6NxzqUhi499CDEjJEZ9i6i9lHJiK2df4dlLAb/4SiWX6+QUzESkK4DEdnCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "symbol.inspect": "1.0.1"
-      },
-      "peerDependencies": {
-        "@ton/crypto": ">=3.2.0"
       }
     },
     "node_modules/edge-currency-accountbased/node_modules/elliptic": {
@@ -20326,8 +20326,7 @@
     "node_modules/symbol.inspect": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol.inspect/-/symbol.inspect-1.0.1.tgz",
-      "integrity": "sha1-4TEluAOMSZbrDfoVZzMq1NzQdj8= sha512-YQSL4duoHmLhsTD1Pw8RW6TZ5MaTX5rXJnqacJottr2P2LZBF/Yvrc3ku4NUpMOm8aM0KOCqM+UAkMA5HWQCzQ==",
-      "dev": true
+      "integrity": "sha1-4TEluAOMSZbrDfoVZzMq1NzQdj8= sha512-YQSL4duoHmLhsTD1Pw8RW6TZ5MaTX5rXJnqacJottr2P2LZBF/Yvrc3ku4NUpMOm8aM0KOCqM+UAkMA5HWQCzQ=="
     },
     "node_modules/table": {
       "version": "6.0.9",
@@ -20624,19 +20623,6 @@
         "axios-request-throttle": "^1.0.0",
         "promise-throttle": "^1.1.2",
         "tonweb-mnemonic": "^1.0.1"
-      }
-    },
-    "node_modules/ton-watcher/node_modules/@ton/core": {
-      "version": "0.59.1",
-      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.59.1.tgz",
-      "integrity": "sha512-SxFBAvutYJaIllTkv82vbHTJhJI6NxzqUhi499CDEjJEZ9i6i9lHJiK2df4dlLAb/4SiWX6+QUzESkK4DEdnCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "symbol.inspect": "1.0.1"
-      },
-      "peerDependencies": {
-        "@ton/crypto": ">=3.2.0"
       }
     },
     "node_modules/tonweb-mnemonic": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@cosmjs/encoding": "^0.32.2",
     "@scure/base": "^1.2.6",
+    "@ton/core": "0.59.1",
     "@unizen-io/unizen-contract-addresses": "^0.0.15",
     "biggystring": "^4.2.3",
     "cleaners": "^0.3.13",

--- a/src/swap/defi/bridgeless.ts
+++ b/src/swap/defi/bridgeless.ts
@@ -106,12 +106,6 @@ const asBridgeTokens = asObject({
   pagination: asPagination
 })
 
-const asReferral = asObject({
-  referral: asObject({
-    commission_rate: asString
-  })
-})
-
 const asInitOptions = asObject({
   // Bridgeless referral id (uint16). When omitted, deposits carry no referral.
   referralId: asOptional(asNumber)
@@ -323,19 +317,10 @@ export function makeBridgelessPlugin(
     const fromDecimals = parseInt(fromTokenInfo.decimals, 10)
     const toDecimals = parseInt(toTokenInfo.decimals, 10)
 
-    // A registered referral id adds its own commission on top of the token's
-    // bridge commission, so include it in the quoted amounts.
-    let commissionRate = toTokenInfo.commission_rate
-    if (referralId !== 0) {
-      const referralRaw = await fetchBridgeless(
-        opts.io.fetch,
-        `/referrals/${referralId}`
-      )
-      commissionRate = add(
-        commissionRate,
-        asReferral(referralRaw).referral.commission_rate
-      )
-    }
+    // A referral id does not change what the user is charged: the bridge
+    // always takes the token's commission_rate, and the referral reward is
+    // paid out of that commission by Bridgeless.
+    const commissionRate = toTokenInfo.commission_rate
 
     // The minimum amount is enforced by the amount of toToken received
     let fromAmount: string

--- a/src/swap/defi/bridgeless.ts
+++ b/src/swap/defi/bridgeless.ts
@@ -1,4 +1,5 @@
 import { base16, base58 } from '@scure/base'
+import { beginCell } from '@ton/core'
 import { add, ceil, lt, mul, sub } from 'biggystring'
 import {
   asArray,
@@ -30,6 +31,7 @@ import {
 } from 'edge-core-js/types'
 import { ethers } from 'ethers'
 
+import { borshString, borshU64 } from '../../util/borsh'
 import {
   getMaxSwappable,
   makeSwapPluginQuote,
@@ -59,6 +61,8 @@ const EDGE_PLUGINID_CHAINID_MAP: Record<string, string> = {
   bitcoin: '0',
   bitcoincash: '5',
   ethereum: '1',
+  solana: '4',
+  ton: '3',
   zano: '2'
 }
 
@@ -196,6 +200,17 @@ const makeBridgelessEvmSpendInfo = ({
         referralId
       ])
 }
+
+// Bridgeless Solana bridge program (reverse-engineered from on-chain deposits).
+const SOLANA_BRIDGE_PROGRAM_ID = '8Jcah8Td4prNTrAvK1L3utWW6t87y1kDYTau7K4k9uDL'
+const SOLANA_BRIDGE_CONFIG = '8c6uRQbVKo6mt9QYdfFx4dH3T1iJ4ZVGxqZSS18L3M4D'
+const SOLANA_SYSTEM_PROGRAM = '11111111111111111111111111111111'
+const SOLANA_BRIDGE_ID = '1' // mainnet bridge id
+// Anchor discriminator: sha256('global:deposit_native').slice(0, 8)
+const SOLANA_DEPOSIT_NATIVE_DISCRIMINATOR = '0d9e0ddf5fd51c06'
+
+// Bridgeless TON MsgDepositNative message opcode.
+const TON_DEPOSIT_NATIVE_OP = 0x5386a723
 
 export function makeBridgelessPlugin(
   opts: EdgeCorePluginOptions
@@ -534,6 +549,106 @@ export function makeBridgelessPlugin(
           fromNativeAmount: fromAmount
         }
       }
+      case 'solana': {
+        // Only native SOL deposits are supported until the bridge program's
+        // `deposit_spl` flow is implemented.
+        if (request.fromTokenId != null) {
+          throw new SwapCurrencyError(swapInfo, request)
+        }
+        // Native SOL deposit via the bridge program's `deposit_native`
+        // instruction. args: (bridgeId, amount, chainId, receiver, referralId)
+        const sender = await getAddress(request.fromWallet)
+        const referralBuf = Buffer.alloc(2)
+        referralBuf.writeUInt16LE(referralId)
+        const data = Buffer.concat([
+          Buffer.from(SOLANA_DEPOSIT_NATIVE_DISCRIMINATOR, 'hex'),
+          borshString(SOLANA_BRIDGE_ID),
+          borshU64(fromAmount),
+          borshString(toChainId),
+          borshString(toAddress),
+          referralBuf
+        ])
+
+        const solanaRequest = {
+          instructions: [
+            {
+              programId: SOLANA_BRIDGE_PROGRAM_ID,
+              keys: [
+                {
+                  pubkey: SOLANA_BRIDGE_CONFIG,
+                  isSigner: false,
+                  isWritable: true
+                },
+                { pubkey: sender, isSigner: true, isWritable: true },
+                {
+                  pubkey: SOLANA_SYSTEM_PROGRAM,
+                  isSigner: false,
+                  isWritable: false
+                }
+              ],
+              data: data.toString('base64')
+            }
+          ],
+          nativeAmount: fromAmount,
+          tokenId: request.fromTokenId
+        }
+
+        const makeTxParams: MakeTxParams = {
+          type: 'MakeTx',
+          unsignedTx: new TextEncoder().encode(JSON.stringify(solanaRequest)),
+          metadata: { assetAction, savedAction }
+        }
+
+        return {
+          request,
+          makeTxParams,
+          swapInfo,
+          fromNativeAmount: fromAmount
+        }
+      }
+      case 'ton': {
+        // Only native TON deposits are supported (no jetton deposits yet).
+        if (request.fromTokenId != null) {
+          throw new SwapCurrencyError(swapInfo, request)
+        }
+        // Native TON deposit: an internal message to the bridge contract whose
+        // body is MsgDepositNative(op, referralId, ref(receiver), ref(network)).
+        const receiverBuf = Buffer.alloc(127)
+        const receiverBytes = Buffer.from(toAddress, 'ascii')
+        if (receiverBytes.length > receiverBuf.length) {
+          throw new SwapCurrencyError(swapInfo, request)
+        }
+        receiverBytes.copy(receiverBuf)
+        const networkBuf = Buffer.alloc(32)
+        Buffer.from(toChainId, 'ascii').copy(networkBuf)
+
+        const body = beginCell()
+          .storeUint(TON_DEPOSIT_NATIVE_OP, 32)
+          .storeUint(referralId, 16)
+          .storeRef(beginCell().storeBuffer(receiverBuf).endCell())
+          .storeRef(beginCell().storeBuffer(networkBuf).endCell())
+          .endCell()
+
+        const tonRequest = {
+          toAddress: bridgeAddress,
+          amount: fromAmount,
+          bodyBoc: Buffer.from(body.toBoc()).toString('base64'),
+          bounce: true
+        }
+
+        const makeTxParams: MakeTxParams = {
+          type: 'MakeTx',
+          unsignedTx: new TextEncoder().encode(JSON.stringify(tonRequest)),
+          metadata: { assetAction, savedAction }
+        }
+
+        return {
+          request,
+          makeTxParams,
+          swapInfo,
+          fromNativeAmount: fromAmount
+        }
+      }
       default: {
         throw new SwapCurrencyError(swapInfo, request)
       }
@@ -569,7 +684,11 @@ export function makeBridgelessPlugin(
             savedAction.actionType === 'swap' &&
             savedAction.orderId != null
           ) {
-            const txHash = txid.startsWith('0x') ? txid : `0x${txid}`
+            // Hex txids (EVM/UTXO/Zano/TON) are 0x-prefixed for the bridge's
+            // order tracking; Solana signatures are base58 and used as-is.
+            const isHexTxid = /^(0x)?[0-9a-fA-F]{64}$/.test(txid)
+            const txHash =
+              isHexTxid && !txid.startsWith('0x') ? `0x${txid}` : txid
             savedAction.orderId = savedAction.orderId.replace(
               '{{TXID}}',
               txHash

--- a/src/util/borsh.ts
+++ b/src/util/borsh.ts
@@ -1,0 +1,22 @@
+import { div, mul, sub } from 'biggystring'
+
+// Borsh-encode a string: little-endian u32 length prefix + utf-8 bytes.
+export const borshString = (value: string): Buffer => {
+  const bytes = Buffer.from(value, 'utf8')
+  const length = Buffer.alloc(4)
+  length.writeUInt32LE(bytes.length)
+  return Buffer.concat([length, bytes])
+}
+
+// Borsh-encode a decimal string as a little-endian u64. Uses biggystring rather
+// than BigInt/writeBigUInt64LE for React Native runtime compatibility.
+export const borshU64 = (value: string): Buffer => {
+  const buf = Buffer.alloc(8)
+  let remaining = value
+  for (let i = 0; i < 8; i++) {
+    const quotient = div(remaining, '256', 0)
+    buf[i] = parseInt(sub(remaining, mul(quotient, '256')))
+    remaining = quotient
+  }
+  return buf
+}

--- a/src/util/swapHelpers.ts
+++ b/src/util/swapHelpers.ts
@@ -269,8 +269,16 @@ export const getMaxSwappable = async <T extends any[]>(
     requestCopy.nativeAmount = maxAmount
     return requestCopy
   } else {
-    // Fallback: Use full balance for makeTx paths
+    // Fallback for makeTx paths: engines that build custom transactions can
+    // report the true spendable max (balance minus fees); otherwise use the
+    // full balance.
     let maxAmount = balance
+    if (
+      'makeTxParams' in swapOrder &&
+      fromWallet.otherMethods?.getMaxTx != null
+    ) {
+      maxAmount = await fromWallet.otherMethods.getMaxTx(swapOrder.makeTxParams)
+    }
     if (fromCurrencyCode === fromWallet.currencyInfo.currencyCode) {
       for (const preTx of swapOrder.preTxs ?? []) {
         maxAmount = sub(maxAmount, preTx.networkFee)


### PR DESCRIPTION
Stacked on #472 (referral id support) — adds two new deposit pathways to the Bridgeless plugin:

- **Solana (native SOL ⇄ Zano SOLx)**: builds the bridge program's `deposit_native` instruction (program `8Jcah8Td…`, Anchor discriminator `sha256("global:deposit_native")[:8]`, borsh args `bridgeId/amount/chainId/receiver/referralId`) and executes it via the Solana engine's new `otherMethods.makeTx`. Borsh u64 encoding uses biggystring (no BigInt) for RN/Hermes compatibility.
- **TON (native TON ⇄ Zano TONx)**: builds the `MsgDepositNative` body cell (op `0x5386a723`, u16 referral inline, 127-byte receiver ref, 32-byte network ref), sent bounceable to the bridge contract via the TON engine's new `otherMethods.makeTx`.
- Order-tracking txids: Solana base58 signatures are no longer 0x-prefixed (hex txids keep the prefix).
- Base (8453) remains disabled in the chain map — its only bridgeable asset (wrapped BTC) has no activity yet; re-enabling is a one-line uncomment.

**Requires** EdgeApp/edge-currency-accountbased#1072 (Solana/TON `makeTx` + SOLx/TONx/FUSDx Zano assets) and pairs with EdgeApp/edge-autobot-server#6 (chain 3/4 deposit forwarding).

**Testing**: both encodings byte-verified against live on-chain Bridgeless deposits (Solana instruction data round-trips a real deposit exactly; TON body cell hash-identical to our builder's output). Live E2E: TON→Zano credited end-to-end through the autobot; Solana deposits build as legacy transactions (a v0 test deposit surfaced that the TSS cannot parse versioned transactions — sig `FkxydurQ…Wr21L` pending Bridgeless-side handling).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes custom bridge deposit encoding and swap quote math on paths that move user funds; incorrect borsh/cell layout or commission math would cause failed deposits or wrong amounts.
> 
> **Overview**
> **Bridgeless** gains **native SOL** and **native TON** deposit paths to/from Zano via wallet `makeTx`: Solana builds the bridge program `deposit_native` instruction (Anchor discriminator + borsh args including referral id); TON builds a `MsgDepositNative` body cell and sends it bounceable to the bridge contract. Only native assets on those chains are supported for now (SPL/jettons rejected). Chain ids **3** (TON) and **4** (Solana) are registered in the plugin map.
> 
> **Referral quoting** is corrected: quotes always use the token `commission_rate` only; a configured `referralId` still rides on deposits for attribution but no longer fetches and adds the referral registry rate (which had massively inflated quoted commissions).
> 
> **Max swaps** for `makeTx` flows now call `fromWallet.otherMethods.getMaxTx` when available instead of using the full balance, avoiding overshoot by network fees.
> 
> Order tracking after approve only **0x-prefixes 64-char hex** txids; **Solana base58** signatures are left unchanged. **`@ton/core`** is added as a direct dependency; shared **borsh** helpers encode Solana instruction data without `BigInt` for RN compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04d626d19ac7a0c36babbc6e8d8dbfea8417987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216504872021058

---

**Update (2026-07-16):** rebased onto `master` (the referral PR #472 merged) and added an initial commit fixing the referral commission quote math that shipped in #472. The referral registry's `commission_rate` is the referrer's *share* of the bridge's fixed 0.3% commission (Edge's id 2 = `0.66` ⇒ ~0.2% of the amount), not an extra rate charged to the user — confirmed with the Bridgeless team. Quotes now always use the token's `commission_rate`; deposits still carry the referral id for attribution. The previous additive math would have quoted a 66.3% commission once a referral id was configured (dormant in production since no build sets one yet).
