### PR TITLE
Filter Changelly assets missing fixRateEnabled

### DIFF
--- a/src/swap/central/changelly.ts
+++ b/src/swap/central/changelly.ts
@@ -368,7 +368,9 @@ export function makeChangellyPlugin({
       const chaincodeArray = Object.values(MAINNET_CODE_TRANSCRIPTION).filter(Boolean)
       const out: ChainCodeTickerMap = new Map()
       for (const asset of data.result) {
-        if (!asset.enabled) continue
+        // Quotes go through the fix-rate API exclusively, so an asset without
+        // fixRateEnabled would surface as swappable and fail at quote time.
+        if (!asset.enabled || !asset.fixRateEnabled) continue
         if (!chaincodeArray.includes(asset.blockchain)) continue
         const tokenCodes = out.get(asset.blockchain) ?? []
         tokenCodes.push({


### PR DESCRIPTION
Follow-up to #471, re-applying the Cursor Bugbot fix that was pushed to the branch after the merge (the fixup landed on the dead branch, not master).

Changelly quotes go through the fix-rate API exclusively (`getFixRateForAmount` / `createFixTransaction`), but the supported-asset filter only checked `asset.enabled`. An enabled asset without `fixRateEnabled` appeared swappable and failed at quote time with a generic currency error. The filter now also requires `fixRateEnabled`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard in asset caching with no auth or payment logic changes; effect is fewer listed pairs and fewer quote-time failures.
> 
> **Overview**
> **Changelly’s supported-asset cache** now skips currencies that are `enabled` but not `fixRateEnabled`, so the swap UI only offers pairs that can actually be quoted.
> 
> Because quotes use **`getFixRateForAmount`** / **`createFixTransaction`** only, assets without fix-rate support were previously listed as swappable and then failed with a generic currency error at quote time. The filter in `fetchSupportedAssets` is tightened to match that API contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e31cdf20b30d764512a3e6ec752fbc783506bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->