### PR TITLE
Add Swapter swap provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added: Swapter swap provider
+
 ## 2.52.2 (2026-07-27)
 
 - fixed: Maya swaps spending RUNE now send to Maya's inbound address instead of depositing into THORChain's own state machine, which misrouted the swap (THORChain read Maya's `=:d:` DASH memo as an unparseable DOGE swap and the deposit failed).

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { makeLetsExchangePlugin } from './swap/central/letsexchange'
 import { makeNexchangePlugin } from './swap/central/nexchange'
 import { makeNymPlugin } from './swap/central/nym'
 import { makeSideshiftPlugin } from './swap/central/sideshift'
+import { makeSwapterPlugin } from './swap/central/swapter'
 import { makeSwapuzPlugin } from './swap/central/swapuz'
 import { makeXgramPlugin } from './swap/central/xgram'
 import { make0xGaslessPlugin } from './swap/defi/0x/0xGasless'
@@ -46,6 +47,7 @@ const plugins = {
   rango: makeRangoPlugin,
   sideshift: makeSideshiftPlugin,
   spookySwap: makeSpookySwapPlugin,
+  swapter: makeSwapterPlugin,
   swapuz: makeSwapuzPlugin,
   mayaprotocol: makeMayaProtocolPlugin,
   thorchain: makeThorchainPlugin,

--- a/src/mappings/swapter.ts
+++ b/src/mappings/swapter.ts
@@ -1,0 +1,137 @@
+/**
+ * Swapter Exchange Plugin Chain Mapping
+ *
+ * See https://docs.swapter.io/ for API documentation
+ * Currency list endpoint, which must be called UNAUTHENTICATED:
+ *
+ * curl -X GET 'https://api.swapter.io/data/coins'
+ *
+ * Sending an `X-API-KEY` header here answers 401 for a valid key, a garbage key
+ * and an empty value alike, which is why the plugin fetches this one route with
+ * `publicHeaders`. A curl carrying the key reproduces an empty ticker map, not
+ * the real list.
+ *
+ * This file maps EdgeCurrencyPluginId -> Swapter network identifier
+ *
+ * Notes:
+ * - Only networks confirmed from `/data/coins` are mapped.
+ * - Unsupported or unverified chains are set to `null`.
+ * - Swapter uses custom network identifiers for some chains:
+ *     - Avalanche C-Chain -> AVAX_C
+ *     - Binance Smart Chain -> BSC
+ *     - Ethereum PoW -> ETHEREUM POW (note the space)
+ *     - Tron -> TRX
+ *     - zkSync Era -> ZKS20
+ *     - WAX -> WAXP
+ * - Some Edge plugin IDs intentionally differ from Swapter naming.
+ * - EVM chains are mapped directly because Swapter identifies them
+ *   by network name instead of chain ID.
+ * - Swapter renames network identifiers over time (Arbitrum was `ARBITRUM`,
+ *   now `ARB`). A stale code here is not caught by any type: mainnet quotes
+ *   still reach the API and fail with Swapter's "combination does not exists"
+ *   error, while token quotes throw `SwapCurrencyError` because `/data/coins`
+ *   returns no ticker set for the unknown network. Re-verify every code against
+ *   `/data/coins` before editing this file.
+ * - A chain whose Edge `currencyCode` differs from Swapter's asset code cannot
+ *   be mapped here alone: `getChainAndTokenCodes` derives the mainnet ticker
+ *   from `currencyInfo.currencyCode`. Three chains need a `SPECIAL_MAINNET_CASES`
+ *   entry in the plugin for that reason: native TON is listed as `GRAM`, Bitcoin
+ *   SV is `BSV` in Edge and `BCHSV` on Swapter (both the network and the asset),
+ *   and the EOS network lists only Vaulta's `A` since the rebrand. Swapter lists
+ *   no `BSV` network at all, so mapping it to `BSV` would break the chain
+ *   outright.
+ * - A mapped network does NOT imply the native asset is quotable. zkSync's
+ *   `ZKS20` lists the `ZK` token but no native ETH, so the network stays mapped
+ *   (tokens quote) while the native is blocked through the plugin's
+ *   `INVALID_TOKEN_IDS`.
+ */
+
+import { EdgeCurrencyPluginId } from '../util/edgeCurrencyPluginIds'
+
+export const swapter = new Map<EdgeCurrencyPluginId, string | null>()
+
+swapter.set('abstract', null)
+swapter.set('algorand', 'ALGO')
+swapter.set('amoy', null)
+swapter.set('arbitrum', 'ARB')
+swapter.set('avalanche', 'AVAX_C')
+swapter.set('axelar', 'AXL')
+swapter.set('badcoin', null)
+swapter.set('base', 'BASE')
+swapter.set('binance', null)
+swapter.set('binancesmartchain', 'BSC')
+swapter.set('bitcoin', 'BTC')
+swapter.set('bitcoincash', 'BCH')
+swapter.set('bitcoincashtestnet', null)
+swapter.set('bitcoingold', null)
+swapter.set('bitcoingoldtestnet', null)
+swapter.set('bitcoinsv', 'BCHSV')
+swapter.set('bitcointestnet', null)
+swapter.set('bitcointestnet4', null)
+swapter.set('bobevm', null)
+swapter.set('botanix', null)
+swapter.set('calibration', null)
+swapter.set('cardano', 'ADA')
+swapter.set('cardanotestnet', null)
+swapter.set('celo', 'CELO')
+swapter.set('coreum', null)
+swapter.set('cosmoshub', 'ATOM')
+swapter.set('dash', 'DASH')
+swapter.set('digibyte', 'DGB')
+swapter.set('dogecoin', 'DOGE')
+swapter.set('eboost', null)
+swapter.set('ecash', 'XEC')
+swapter.set('eos', 'EOS')
+swapter.set('ethDev', null)
+swapter.set('ethereum', 'ETH')
+swapter.set('ethereumclassic', 'ETC')
+swapter.set('ethereumpow', 'ETHEREUM POW')
+swapter.set('fantom', null)
+swapter.set('feathercoin', null)
+swapter.set('filecoin', 'FIL')
+swapter.set('filecoinfevm', null)
+swapter.set('filecoinfevmcalibration', null)
+swapter.set('fio', null)
+swapter.set('groestlcoin', null)
+swapter.set('hedera', 'HBAR')
+swapter.set('holesky', null)
+swapter.set('hyperevm', 'HYPEREVM')
+swapter.set('liberland', null)
+swapter.set('liberlandtestnet', null)
+swapter.set('litecoin', 'LTC')
+swapter.set('mayachain', null)
+swapter.set('monad', 'MONAD')
+swapter.set('monero', 'XMR')
+swapter.set('nym', null)
+swapter.set('opbnb', null)
+swapter.set('optimism', 'OP')
+swapter.set('osmosis', 'OSMO')
+swapter.set('piratechain', null)
+swapter.set('pivx', null)
+swapter.set('polkadot', 'DOT')
+swapter.set('polygon', 'POL')
+swapter.set('pulsechain', null)
+swapter.set('qtum', 'QTUM')
+swapter.set('ravencoin', null)
+swapter.set('ripple', 'XRP')
+swapter.set('rsk', null)
+swapter.set('sepolia', null)
+swapter.set('smartcash', null)
+swapter.set('solana', 'SOL')
+swapter.set('sonic', 'SONIC')
+swapter.set('stellar', 'XLM')
+swapter.set('sui', 'SUI')
+swapter.set('suitestnet', null)
+swapter.set('telos', 'TELOS')
+swapter.set('tezos', 'XTZ')
+swapter.set('thorchainrune', 'RUNE')
+swapter.set('thorchainrunestagenet', null)
+swapter.set('ton', 'TON')
+swapter.set('tron', 'TRX')
+swapter.set('ufo', null)
+swapter.set('vertcoin', null)
+swapter.set('wax', 'WAXP')
+swapter.set('zano', null)
+swapter.set('zcash', 'ZEC')
+swapter.set('zcoin', null)
+swapter.set('zksync', 'ZKS20')

--- a/src/swap/central/swapter.ts
+++ b/src/swap/central/swapter.ts
@@ -1,0 +1,747 @@
+import { ceil, floor, gt, lt } from 'biggystring'
+import {
+  asArray,
+  asEither,
+  asJSON,
+  asMaybe,
+  asNull,
+  asObject,
+  asString
+} from 'cleaners'
+import {
+  EdgeCorePluginOptions,
+  EdgeMemo,
+  EdgeSpendInfo,
+  EdgeSwapInfo,
+  EdgeSwapPlugin,
+  EdgeSwapQuote,
+  EdgeSwapRequest,
+  SwapAboveLimitError,
+  SwapBelowLimitError,
+  SwapCurrencyError
+} from 'edge-core-js/types'
+
+import { swapter as swapterMapping } from '../../mappings/swapter'
+import {
+  ChainCodeTickerMap,
+  checkInvalidTokenIds,
+  checkWhitelistedMainnetCodes,
+  CurrencyPluginIdSwapChainCodeMap,
+  denominationToNative,
+  EdgeIdSwapIdMap,
+  ensureInFuture,
+  getChainAndTokenCodes,
+  getMaxSwappable,
+  InvalidTokenIds,
+  makeSwapPluginQuote,
+  mapToRecord,
+  nativeToDenomination,
+  SwapOrder
+} from '../../util/swapHelpers'
+import { convertRequest, getAddress, memoType } from '../../util/utils'
+import { asNumberString, EdgeSwapRequestPlugin, StringMap } from '../types'
+import { asOptionalBlank } from './changenow'
+
+const pluginId = 'swapter'
+const orderUri = 'https://swapter.io/exchange-status/'
+const apiBaseUrl = 'https://api.swapter.io'
+
+/** Swapter returns no quote expiration, so bound it locally. */
+const EXPIRATION_MS = 1000 * 60 * 30
+
+/**
+ * Swapter's zkSync network (`ZKS20`) lists the `ZK` token but NOT native ETH, so
+ * a native zkSync quote reaches the API and is rejected as a coin/network
+ * combination that does not exist. Blocking the null tokenId keeps the network
+ * mapped, which is what makes its tokens quotable.
+ */
+const INVALID_TOKEN_IDS: InvalidTokenIds = {
+  from: { zksync: [null] },
+  to: { zksync: [null] }
+}
+
+/** How long a fetched `/data/coins` ticker map is reused. */
+const ASSET_CACHE_MS = 1000 * 60 * 60 // 1 hour
+
+export const swapInfo: EdgeSwapInfo = {
+  pluginId,
+  isDex: false,
+  displayName: 'Swapter',
+  supportEmail: 'support@swapter.io'
+}
+
+const asInitOptions = asObject({ apiKey: asString })
+
+/**
+ * Chains whose default address is not the one a CEX can pay or refund. Zcash
+ * lists its unified address first, which Swapter cannot send to or refund, so
+ * the deposit or the payout would be stranded. Matches `changenow` and
+ * `letsexchange`.
+ */
+const addressTypeMap: StringMap = {
+  zcash: 'transparentAddress'
+}
+
+const asSwapterNetwork = asObject({
+  network: asString,
+  contract: asEither(asNull, asString)
+})
+
+const asSwapterAssetsResponse = asObject({
+  assets: asArray(
+    asObject({
+      currency: asString,
+      networks: asObject({
+        deposit: asArray(asSwapterNetwork),
+        withdraw: asArray(asSwapterNetwork)
+      })
+    })
+  )
+})
+
+const asSwapterDepositRangeResponse = asObject({
+  min: asNumberString,
+  max: asNumberString
+})
+
+const asSwapterErrorResponse = asJSON(
+  asObject({
+    error: asObject({
+      // Swapter sends string codes today, but its amount fields are numbers, so
+      // accept either rather than silently falling back to a generic error.
+      code: asNumberString,
+      message: asMaybe(asString),
+      // Present only on the limit rejections below, carrying the bound that was
+      // violated in the deposit asset's denomination.
+      min: asMaybe(asNumberString),
+      max: asMaybe(asNumberString)
+    })
+  })
+)
+
+/**
+ * Codes meaning Swapter does not serve this pair, which happens whenever it
+ * drops or renames an asset this mapping still lists. Those are not failures,
+ * so they become `SwapCurrencyError` and Swapter drops out of the quote race.
+ *
+ * The two endpoints do NOT share an error vocabulary: the deposit range answers
+ * a bare service code for either side of the pair, while create namespaces its
+ * own. Both spellings are listed because either call can be the one that
+ * discovers the pair is gone.
+ */
+const UNSUPPORTED_PAIR_CODES = [
+  // Deposit range: coin/network combination does not exist.
+  '1',
+  '2',
+  // Create: unknown coin, unknown deposit network, unknown withdraw network.
+  'io.swapter.controller.swap.factory:1',
+  'io.swapter.controller.swap.factory:2',
+  'io.swapter.controller.swap.factory:3'
+]
+
+/**
+ * Codes `create` returns for a deposit amount outside the pair's range. They
+ * were a single code until Swapter split them, so the only way to tell a floor
+ * from a ceiling used to be string-matching their English message.
+ */
+const BELOW_MINIMUM_CODE = 'io.swapter.controller.swap.factory:6'
+const ABOVE_MAXIMUM_CODE = 'io.swapter.controller.swap.factory:9'
+
+/**
+ * Swapter's Edge-specific adapter routes. Prefer them over the `/v2` originals
+ * for two reasons that are not cosmetic:
+ *
+ * - They serialize every numeric field as a string. The `/v2` routes return
+ *   unquoted JSON numbers, so an 18-decimal amount loses its low digits in
+ *   `JSON.parse` before this plugin can read it.
+ * - The range is authoritative. `/v2/swap/min-amount` reports a LOWER minimum
+ *   than create actually enforces (0.014153 vs 0.016006 ETH on ETH->LTC), so
+ *   quoting against it let an amount pass this plugin's own check and then fail
+ *   create.
+ */
+const DEPOSIT_RANGE_PATH = '/adapter/edge/swap/deposit-range'
+const CREATE_PATH = '/adapter/edge/swap/create'
+
+const asSwapterCreateResponse = asObject({
+  uid: asString,
+  deposit: asObject({
+    address: asString,
+    /**
+     * Memo-based chains (XRP, XLM, TON…) carry a destination tag that Swapter
+     * may return as a number. `asMaybe(asString)` would swallow that into
+     * `undefined` and build a spend with NO memo, stranding the deposit, so
+     * accept number-or-string and treat only null/blank as absent.
+     */
+    memo: asOptionalBlank(asNumberString)
+  }),
+  withdraw: asObject({
+    amount: asObject({
+      expected: asNumberString
+    })
+  })
+})
+
+/**
+ * Swapter's create endpoint spells the fixed-rate type `fix`, NOT `fixed`. An
+ * unrecognized type is not rejected as a bad request: the server answers 500
+ * (`io.swapter.controller.swap.factory:7`), which is indistinguishable from a
+ * pair it cannot fix, so sending `fixed` silently downgraded EVERY quote to the
+ * floating fallback below.
+ */
+type SwapterSwapType = 'float' | 'fix'
+
+/**
+ * Wraps the Edge error from a create call Swapter REJECTED (non-ok response, so
+ * no order was created). The fixed-then-float fallback retries ONLY on this, so
+ * a failure after a successful create never spawns a second order.
+ */
+class SwapterCreateRejected extends Error {
+  readonly edgeError: Error
+  constructor(edgeError: Error) {
+    super('Swapter create rejected')
+    this.name = 'SwapterCreateRejected'
+    this.edgeError = edgeError
+  }
+}
+
+export const MAINNET_CODE_TRANSCRIPTION: CurrencyPluginIdSwapChainCodeMap = mapToRecord(
+  swapterMapping
+)
+
+/**
+ * Overrides for mainnet assets whose Swapter coin code is NOT the Edge mainnet
+ * ticker. `getChainAndTokenCodes` derives a mainnet coin from
+ * `currencyInfo.currencyCode`, which is wrong whenever Swapter uses a different
+ * symbol for the same asset. Without the override the quote sends a coin
+ * Swapter does not list, so `deposit-range` and `create` both reject the pair
+ * with their unsupported-pair code and Swapter drops out of the quote race.
+ *
+ * - Native TON (Edge `TON`) is listed as `GRAM`.
+ * - Bitcoin SV is `BSV` in Edge and `BCHSV` on Swapter, network and asset alike.
+ * - The EOS network carries only Vaulta's `A` since the rebrand; Edge still
+ *   calls the chain's native asset `EOS`.
+ */
+const SPECIAL_MAINNET_CASES: EdgeIdSwapIdMap = new Map([
+  ['ton', new Map([[null, { chainCode: 'TON', tokenCode: 'GRAM' }]])],
+  ['bitcoinsv', new Map([[null, { chainCode: 'BCHSV', tokenCode: 'BCHSV' }]])],
+  ['eos', new Map([[null, { chainCode: 'EOS', tokenCode: 'A' }]])]
+])
+
+/**
+ * Errors that describe the PAIR or the AMOUNT rather than the swap type, so
+ * retrying the same request as a floating order earns the identical rejection.
+ */
+const PAIR_LEVEL_ERROR_NAMES = [
+  'SwapCurrencyError',
+  'SwapBelowLimitError',
+  'SwapAboveLimitError'
+]
+
+/**
+ * edge-core-js builds its swap errors with constructors that RETURN a plain
+ * `Error` carrying a `name`, never `this`, so `instanceof` against them is
+ * always false and silently classifies every one of them as a generic failure.
+ * Match the name instead, which is the field core's own `asMaybeSwap*Error`
+ * cleaners key off.
+ */
+const isPairLevelError = (error: unknown): boolean =>
+  error instanceof Error && PAIR_LEVEL_ERROR_NAMES.includes(error.name)
+
+/**
+ * Convert a deposit-side limit from Swapter's denomination to the native units
+ * Edge's limit errors carry. `denominationToNative` is a plain multiply, so a
+ * bound with more decimals than the asset's denomination lands on a fractional
+ * value, and native amounts must be integer atomic units. Round each bound
+ * INWARD — minimums up, maximums down — so the rounding can never widen the
+ * range past what Swapter accepts and let a doomed amount through.
+ */
+const toNativeLimit = (
+  request: EdgeSwapRequestPlugin,
+  amount: string,
+  bound: 'min' | 'max'
+): string => {
+  const native = denominationToNative(
+    request.fromWallet,
+    amount,
+    request.fromTokenId
+  )
+  return bound === 'min' ? ceil(native, 0) : floor(native, 0)
+}
+
+export function makeSwapterPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
+  const { io, log } = opts
+
+  // Per-plugin rather than module-level: the core builds one plugin instance, so
+  // the cache lifetime is unchanged in production, while a second instance (a
+  // test) can no longer inherit a map the first one stamped.
+  let chainCodeTickerMap: ChainCodeTickerMap = new Map()
+  let lastUpdated = 0
+  const { fetchCors = io.fetch } = io
+  const initOptions = asInitOptions(opts.initOptions)
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-API-KEY': initOptions.apiKey,
+    Accept: 'application/json'
+  }
+
+  /**
+   * `/data/coins` is public and rejects any request that carries an
+   * `X-API-KEY` header at all — it answers 401 for a valid-format key, a
+   * garbage key and an empty value alike, but 200 with no key. Sending the key
+   * here would leave the ticker map permanently empty, which is silent: the
+   * failure is only warned, and every token quote then dies in
+   * `getChainAndTokenCodes` with `SwapCurrencyError`.
+   */
+  const publicHeaders = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  }
+
+  async function fetchSupportedAssets(): Promise<void> {
+    if (lastUpdated > Date.now() - ASSET_CACHE_MS) return
+
+    try {
+      const response = await fetchCors(apiBaseUrl + '/data/coins', {
+        headers: publicHeaders
+      })
+
+      if (!response.ok) {
+        const message = await response.text()
+        throw new Error(message)
+      }
+
+      const json = await response.json()
+      const { assets } = asSwapterAssetsResponse(json)
+
+      const chaincodeArray = Object.values(MAINNET_CODE_TRANSCRIPTION)
+      const out: ChainCodeTickerMap = new Map()
+
+      for (const asset of assets) {
+        for (const depositNetwork of asset.networks.deposit) {
+          const canWithdraw = asset.networks.withdraw.some(
+            withdrawNetwork =>
+              withdrawNetwork.network === depositNetwork.network &&
+              withdrawNetwork.contract === depositNetwork.contract
+          )
+
+          if (!canWithdraw) continue
+          if (!chaincodeArray.includes(depositNetwork.network)) continue
+
+          const tokenCodes = out.get(depositNetwork.network) ?? []
+
+          tokenCodes.push({
+            tokenCode: asset.currency,
+            contractAddress: depositNetwork.contract ?? null
+          })
+
+          out.set(depositNetwork.network, tokenCodes)
+        }
+      }
+
+      // Stamp the cache ONLY on a result that carries assets. A successful but
+      // empty response (an outage answering `{ assets: [] }`, or a snapshot
+      // whose networks no longer intersect this mapping) would otherwise be
+      // cached for the full TTL, and every token quote in that hour would fail
+      // as an unsupported pair rather than retrying.
+      if (out.size > 0) {
+        chainCodeTickerMap = out
+        lastUpdated = Date.now()
+      } else {
+        log.warn('Swapter: /data/coins returned no usable assets')
+      }
+    } catch (e: unknown) {
+      log.warn('Swapter: Error updating supported assets', e)
+    }
+  }
+
+  /**
+   * Translate a non-ok Swapter response into the right Edge error. An
+   * unquotable pair becomes `SwapCurrencyError` so the GUI drops Swapter for
+   * this request; anything else is a real provider failure and surfaces as one.
+   */
+  const swapterError = (
+    stage: string,
+    status: number,
+    text: string,
+    request: EdgeSwapRequestPlugin,
+    logError: boolean = true
+  ): Error => {
+    const errorResponse = asMaybe(asSwapterErrorResponse)(text)
+    if (errorResponse != null) {
+      const { code, min, max } = errorResponse.error
+
+      if (UNSUPPORTED_PAIR_CODES.includes(code)) {
+        return new SwapCurrencyError(swapInfo, request)
+      }
+
+      // The deposit range is quoted live and moves with the rate, so an amount
+      // that cleared the range check above can still be out of bounds by the
+      // time `create` runs. Carry the bound Swapter rejected against, so the
+      // user is told the real limit instead of a generic provider failure.
+      // Map the code even when the bound is missing: core's limit errors take
+      // `undefined` and render without a number. Requiring the bound would drop
+      // a bound-less rejection to a generic error, which is not pair-level, so
+      // the fixed-then-float fallback would spend a second create retrying the
+      // same amount Swapter just refused.
+      if (code === BELOW_MINIMUM_CODE) {
+        return new SwapBelowLimitError(
+          swapInfo,
+          min != null ? toNativeLimit(request, min, 'min') : undefined
+        )
+      }
+      if (code === ABOVE_MAXIMUM_CODE) {
+        return new SwapAboveLimitError(
+          swapInfo,
+          max != null ? toNativeLimit(request, max, 'max') : undefined
+        )
+      }
+    }
+    // The fixed-rate attempt is expected to fail for pairs Swapter cannot fix
+    // (it 500s), and the caller falls back to a float quote, so suppress the
+    // warning there rather than logging a provider error on every quote.
+    if (logError) log.warn(`Swapter ${stage} API error response:`, text)
+    return new Error(`Swapter ${stage} returned error code ${status}`)
+  }
+
+  /**
+   * Shared quote setup: gate the direction, resolve Swapter's asset codes and
+   * both addresses, and enforce the pair's deposit range. Creates NO order, so
+   * both the probe and the real quote can call it.
+   *
+   * `enforceMax` is false only for the probe: a max-swap probe deliberately
+   * quotes the whole pre-fee balance to discover the ceiling, so a balance above
+   * the range must clamp through `getMaxSpendable` rather than throw
+   * `SwapAboveLimitError` on an amount the user never asked to send.
+   */
+  const fetchQuoteBase = async (
+    request: EdgeSwapRequestPlugin,
+    enforceMax: boolean
+  ): Promise<{
+    swapterCodes: {
+      fromCurrencyCode: string
+      fromMainnetCode: string
+      toCurrencyCode: string
+      toMainnetCode: string
+    }
+    sourceAmount: string
+    fromAddress: string
+    toAddress: string
+  }> => {
+    const { fromWallet, toWallet, quoteFor } = request
+
+    // Swapter's create endpoint only accepts a deposit amount, so reverse
+    // quotes are unsupported. `max` never reaches here: `getMaxSwappable`
+    // rewrites it into a `from` quote before either quote path runs.
+    if (quoteFor !== 'from') {
+      throw new SwapCurrencyError(swapInfo, request)
+    }
+
+    const swapterCodes = await getChainAndTokenCodes(
+      request,
+      swapInfo,
+      chainCodeTickerMap,
+      MAINNET_CODE_TRANSCRIPTION,
+      SPECIAL_MAINNET_CASES
+    )
+
+    // Grab addresses:
+    const [fromAddress, toAddress] = await Promise.all([
+      getAddress(fromWallet, addressTypeMap[fromWallet.currencyInfo.pluginId]),
+      getAddress(toWallet, addressTypeMap[toWallet.currencyInfo.pluginId])
+    ])
+
+    // Convert the native amount to a denomination:
+    const sourceAmount = nativeToDenomination(
+      fromWallet,
+      request.nativeAmount,
+      request.fromTokenId
+    )
+
+    const depositRangeResponse = await fetchCors(
+      apiBaseUrl + DEPOSIT_RANGE_PATH,
+      {
+        headers,
+        method: 'POST',
+        body: JSON.stringify({
+          deposit: {
+            coin: swapterCodes.fromCurrencyCode,
+            network: swapterCodes.fromMainnetCode
+          },
+          withdraw: {
+            coin: swapterCodes.toCurrencyCode,
+            network: swapterCodes.toMainnetCode
+          }
+        })
+      }
+    )
+
+    if (!depositRangeResponse.ok) {
+      const text = await depositRangeResponse.text()
+      throw swapterError(
+        'deposit range',
+        depositRangeResponse.status,
+        text,
+        request
+      )
+    }
+
+    const depositRangeJson = await depositRangeResponse.json()
+    const { min, max } = asSwapterDepositRangeResponse(depositRangeJson)
+
+    if (lt(sourceAmount, min)) {
+      throw new SwapBelowLimitError(
+        swapInfo,
+        toNativeLimit(request, min, 'min')
+      )
+    }
+
+    if (enforceMax && gt(sourceAmount, max)) {
+      throw new SwapAboveLimitError(
+        swapInfo,
+        toNativeLimit(request, max, 'max')
+      )
+    }
+
+    return { swapterCodes, sourceAmount, fromAddress, toAddress }
+  }
+
+  /**
+   * `getMaxSwappable` probe: build a `SwapOrder` from the minimum check alone,
+   * targeting the user's own refund address so `getMaxSpendable` can estimate
+   * fees WITHOUT creating an abandoned Swapter order. Only the `spendInfo`
+   * shape is used to price fees, so no quote endpoint is needed here; the
+   * trimmed amount it computes is then run through `fetchSwapQuoteInner`, which
+   * creates exactly one order and returns the authoritative amounts.
+   */
+  const fetchProbeOrder = async (
+    request: EdgeSwapRequestPlugin
+  ): Promise<SwapOrder> => {
+    const { fromAddress } = await fetchQuoteBase(request, false)
+
+    const spendInfo: EdgeSpendInfo = {
+      tokenId: request.fromTokenId,
+      spendTargets: [
+        {
+          nativeAmount: request.nativeAmount,
+          publicAddress: fromAddress
+        }
+      ],
+      networkFeeOption: 'high',
+      // This probe is never broadcast: it exists only so `getMaxSpendable` can
+      // price the network fee before the real order (and its deposit address)
+      // exists. Its target is the user's own from-address, which EVM engines
+      // reject with `SpendToSelfError` (the public key IS the address), throwing
+      // out of `getMaxSwappable` and failing every max swap from an EVM wallet.
+      // The real order below keeps all checks.
+      skipChecks: true,
+      assetAction: {
+        assetActionType: 'swap'
+      }
+    }
+
+    return {
+      request,
+      spendInfo,
+      swapInfo,
+      fromNativeAmount: request.nativeAmount,
+      expirationDate: ensureInFuture(new Date(Date.now() + EXPIRATION_MS))
+    }
+  }
+
+  const fetchSwapQuoteInner = async (
+    request: EdgeSwapRequestPlugin,
+    swapType: SwapterSwapType,
+    logCreateError: boolean = true
+  ): Promise<SwapOrder> => {
+    const { fromWallet, toWallet } = request
+    const {
+      swapterCodes,
+      sourceAmount,
+      fromAddress,
+      toAddress
+    } = await fetchQuoteBase(request, true)
+
+    const response = await fetchCors(apiBaseUrl + CREATE_PATH, {
+      headers,
+      method: 'POST',
+      body: JSON.stringify({
+        info: {
+          type: swapType,
+          refundAddress: fromAddress,
+          userEmail: null
+        },
+        deposit: {
+          coin: swapterCodes.fromCurrencyCode,
+          network: swapterCodes.fromMainnetCode,
+          // Send the exact denomination string. `Number(sourceAmount)` would
+          // round a high-precision amount, making the order's deposit disagree
+          // with the `request.nativeAmount` actually sent below. Swapter's
+          // create endpoint accepts the amount as a string.
+          amount: sourceAmount
+        },
+        withdraw: {
+          coin: swapterCodes.toCurrencyCode,
+          network: swapterCodes.toMainnetCode,
+          address: toAddress,
+          memo: null
+        }
+      })
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      const error = swapterError(
+        'create',
+        response.status,
+        text,
+        request,
+        logCreateError
+      )
+      // An unsupported pair and an out-of-range amount both apply to BOTH swap
+      // types, so propagate those directly with no float retry — retrying only
+      // spends another create call to earn the same rejection, and the float
+      // error would then mask the limit the user needs to see. Wrap only a
+      // fixed-specific rejection (Swapter 500s `type: 'fix'` on pairs it
+      // cannot fix) so the fallback retries ONLY those, and never after a
+      // successful create (which is thrown bare below and never double-orders).
+      if (isPairLevelError(error)) throw error
+      throw new SwapterCreateRejected(error)
+    }
+    const responseJson = await response.json()
+
+    let quoteReply
+    try {
+      quoteReply = asSwapterCreateResponse(responseJson)
+    } catch (error: unknown) {
+      log.warn('Unexpected Swapter API response:', JSON.stringify(responseJson))
+      throw error
+    }
+
+    const fromNativeAmount = request.nativeAmount
+
+    // Floor the payout: rounding could inflate the displayed receive amount
+    // above what Swapter actually sends, over-promising the user.
+    const toNativeAmount = floor(
+      denominationToNative(
+        toWallet,
+        quoteReply.withdraw.amount.expected,
+        request.toTokenId
+      ),
+      0
+    )
+    const memos: EdgeMemo[] =
+      quoteReply.deposit.memo == null
+        ? []
+        : [
+            {
+              type: memoType(fromWallet.currencyInfo.pluginId),
+              value: quoteReply.deposit.memo
+            }
+          ]
+
+    // Make the transaction:
+    const spendInfo: EdgeSpendInfo = {
+      tokenId: request.fromTokenId,
+      spendTargets: [
+        {
+          nativeAmount: fromNativeAmount,
+          publicAddress: quoteReply.deposit.address
+        }
+      ],
+      memos,
+      networkFeeOption: 'high',
+      assetAction: {
+        assetActionType: 'swap'
+      },
+      savedAction: {
+        actionType: 'swap',
+        swapInfo,
+        orderId: quoteReply.uid,
+        orderUri: orderUri + quoteReply.uid,
+        isEstimate: swapType === 'float',
+        toAsset: {
+          pluginId: toWallet.currencyInfo.pluginId,
+          tokenId: request.toTokenId,
+          nativeAmount: toNativeAmount
+        },
+        fromAsset: {
+          pluginId: fromWallet.currencyInfo.pluginId,
+          tokenId: request.fromTokenId,
+          nativeAmount: fromNativeAmount
+        },
+        payoutAddress: toAddress,
+        payoutWalletId: toWallet.id,
+        refundAddress: fromAddress
+      }
+    }
+
+    return {
+      request,
+      spendInfo,
+      swapInfo,
+      fromNativeAmount,
+      expirationDate: ensureInFuture(new Date(Date.now() + EXPIRATION_MS))
+    }
+  }
+
+  const out: EdgeSwapPlugin = {
+    swapInfo,
+
+    async fetchSwapQuote(req: EdgeSwapRequest): Promise<EdgeSwapQuote> {
+      const request = convertRequest(req)
+
+      await fetchSupportedAssets()
+
+      // An empty ticker map is a provider outage, not an unsupported pair.
+      // `getChainAndTokenCodes` still derives mainnet codes from the wallets'
+      // own `currencyInfo`, so mainnet quotes would sail through while every
+      // token quote threw `SwapCurrencyError` and the GUI reported the pair as
+      // unsupported. Fail the whole quote instead, so the next one retries.
+      if (chainCodeTickerMap.size === 0) {
+        throw new Error('Swapter is unavailable: no supported assets')
+      }
+
+      checkInvalidTokenIds(INVALID_TOKEN_IDS, request, swapInfo)
+      checkWhitelistedMainnetCodes(
+        MAINNET_CODE_TRANSCRIPTION,
+        request,
+        swapInfo
+      )
+
+      const newRequest = await getMaxSwappable(fetchProbeOrder, request)
+
+      // Prefer a fixed-rate order, falling back to a floating quote, the
+      // convention the other central plugins follow (see changenow). Selecting
+      // the rate from `userSettings` instead left the plugin stuck on float,
+      // since the GUI never passes a `swapType`. Swapter's create endpoint 500s
+      // on `type: 'fix'` for pairs it cannot fix, so that attempt is expected
+      // to fail for those and its create error is not logged.
+      let swapOrder: SwapOrder
+      try {
+        swapOrder = await fetchSwapQuoteInner(newRequest, 'fix', false)
+      } catch (error: unknown) {
+        // Only fall back to a floating quote when Swapter REJECTED the fixed
+        // create (no order was made). Any other error (an order was created, or
+        // a below-limit/unsupported error from the shared setup) propagates
+        // unchanged, so it is never masked and no second order is created.
+        if (!(error instanceof SwapterCreateRejected)) throw error
+        try {
+          swapOrder = await fetchSwapQuoteInner(newRequest, 'float')
+        } catch (floatError: unknown) {
+          // If the float create was ALSO cleanly rejected (no order), surface
+          // the fixed-rate error so limit/currency errors keep their ranking in
+          // `pickBestError`, matching the sibling plugins. If the float attempt
+          // failed AFTER creating an order (e.g. an unparseable response),
+          // surface THAT error, so a live float order is never masked behind the
+          // fixed-rate rejection.
+          if (floatError instanceof SwapterCreateRejected) throw error.edgeError
+          throw floatError
+        }
+      }
+      return await makeSwapPluginQuote(swapOrder)
+    }
+  }
+
+  return out
+}

--- a/test/partnerJson/partnerJson.test.ts
+++ b/test/partnerJson/partnerJson.test.ts
@@ -33,6 +33,10 @@ import {
   swapInfo as sideshiftSwapInfo
 } from '../../src/swap/central/sideshift'
 import {
+  MAINNET_CODE_TRANSCRIPTION as swapterMainnetTranscription,
+  swapInfo as swapterSwapInfo
+} from '../../src/swap/central/swapter'
+import {
   ChainCodeTickerMap,
   getChainAndTokenCodes
 } from '../../src/util/swapHelpers'
@@ -41,6 +45,7 @@ import changenowChainCodeTickerJson from './changenowMap.json'
 import letsexchangeChainCodeTickerJson from './letsexchangeMap.json'
 import nexchangeChainCodeTickerJson from './nexchangeMap.json'
 import sideshiftChainCodeTickerJson from './sideshiftMap.json'
+import swapterChainCodeTickerJson from './swapterMap.json'
 
 const btcWallet = {
   currencyInfo: {
@@ -166,6 +171,18 @@ const sideshift = async (request: EdgeSwapRequest): Promise<Codes> => {
     sideshiftMainnetTranscription
   )
 }
+const swapter = async (request: EdgeSwapRequest): Promise<Codes> => {
+  const swapterChainCodeTickerMap = getChainCodeTickerMap(
+    swapterChainCodeTickerJson
+  )
+
+  return await getChainAndTokenCodes(
+    request,
+    swapterSwapInfo,
+    swapterChainCodeTickerMap,
+    swapterMainnetTranscription
+  )
+}
 
 describe(`swap btc to eth`, function () {
   const request: EdgeSwapRequest = {
@@ -221,6 +238,15 @@ describe(`swap btc to eth`, function () {
       fromMainnetCode: 'bitcoin',
       fromCurrencyCode: 'BTC',
       toMainnetCode: 'ethereum',
+      toCurrencyCode: 'ETH'
+    })
+  })
+  it('swapter', async function () {
+    const result = await swapter(request)
+    return assert.deepEqual(result, {
+      fromMainnetCode: 'BTC',
+      fromCurrencyCode: 'BTC',
+      toMainnetCode: 'ETH',
       toCurrencyCode: 'ETH'
     })
   })
@@ -283,6 +309,15 @@ describe(`swap btc to avax`, function () {
       toCurrencyCode: 'AVAX'
     })
   })
+  it('swapter', async function () {
+    const result = await swapter(request)
+    return assert.deepEqual(result, {
+      fromMainnetCode: 'BTC',
+      fromCurrencyCode: 'BTC',
+      toMainnetCode: 'AVAX_C',
+      toCurrencyCode: 'AVAX'
+    })
+  })
 })
 
 describe(`swap btc to usdt (avax c-chain)`, function () {
@@ -339,6 +374,15 @@ describe(`swap btc to usdt (avax c-chain)`, function () {
       fromMainnetCode: 'bitcoin',
       fromCurrencyCode: 'BTC',
       toMainnetCode: 'avax',
+      toCurrencyCode: 'USDT'
+    })
+  })
+  it('swapter', async function () {
+    const result = await swapter(request)
+    return assert.deepEqual(result, {
+      fromMainnetCode: 'BTC',
+      fromCurrencyCode: 'BTC',
+      toMainnetCode: 'AVAX_C',
       toCurrencyCode: 'USDT'
     })
   })

--- a/test/partnerJson/swapterMap.json
+++ b/test/partnerJson/swapterMap.json
@@ -1,0 +1,3538 @@
+[
+  [
+    "ADA",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ADA"
+      },
+      {
+        "contractAddress": "94cbb4fcbcaa2975779f273b263eb3b5f24a9951e446d6dc4c135864",
+        "tokenCode": "REVU"
+      },
+      {
+        "contractAddress": "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f.534e454b",
+        "tokenCode": "SNEK"
+      },
+      {
+        "contractAddress": "5d16cc1a177b5d9ba9cfa9793b07e60f1fb70fea1f8aef064415d114.494147",
+        "tokenCode": "IAG"
+      },
+      {
+        "contractAddress": "0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa.4e49474854",
+        "tokenCode": "NIGHT"
+      },
+      {
+        "contractAddress": "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c6.4d494e",
+        "tokenCode": "MIN"
+      }
+    ]
+  ],
+  [
+    "ALGO",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ALGO"
+      }
+    ]
+  ],
+  [
+    "ARB",
+    [
+      {
+        "contractAddress": "0x374c5fb7979d5fdbaad2d95409e235e5cbdfd43c",
+        "tokenCode": "MLK"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "ETH"
+      },
+      {
+        "contractAddress": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": "0x9623063377ad1b27544c965ccd7342f7ea7e88c7",
+        "tokenCode": "GRT"
+      },
+      {
+        "contractAddress": "0x5575552988a3a80504bbaeb1311674fcfd40ad4b",
+        "tokenCode": "SPA"
+      },
+      {
+        "contractAddress": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+        "tokenCode": "GMX"
+      },
+      {
+        "contractAddress": "0x539bde0d7dbd336b79148aa742883198bbf60342",
+        "tokenCode": "MAGIC"
+      },
+      {
+        "contractAddress": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "tokenCode": "ARB"
+      },
+      {
+        "contractAddress": "0x0c880f6761f1af8d9aa9c466984b80dab9a8c9e8",
+        "tokenCode": "PENDLE"
+      },
+      {
+        "contractAddress": "0x4cb9a7ae498cedcbb5eae9f25736ae7d428c9d66",
+        "tokenCode": "XAI"
+      },
+      {
+        "contractAddress": "0x1337420ded5adb9980cfc35f8f2b054ea86f8ab1",
+        "tokenCode": "SQD"
+      },
+      {
+        "contractAddress": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+        "tokenCode": "ZRO"
+      },
+      {
+        "contractAddress": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+        "tokenCode": "LAVA"
+      },
+      {
+        "contractAddress": "0x1cd9a56c8c2ea913c70319a44da75e99255aa46f",
+        "tokenCode": "OBT"
+      },
+      {
+        "contractAddress": "0x25118290e6a5f4139381d072181157035864099d",
+        "tokenCode": "RAIN"
+      },
+      {
+        "contractAddress": "0x68731d6f14b827bbcffbebb62b19daa18de1d79c",
+        "tokenCode": "IDOS"
+      },
+      {
+        "contractAddress": "0x0c1c1c109fe34733fca54b82d7b46b75cfb71f6e",
+        "tokenCode": "CHIP"
+      },
+      {
+        "contractAddress": "0x61A1ff55C5216b636a294A07D77C6F4Df10d3B56",
+        "tokenCode": "APEX"
+      }
+    ]
+  ],
+  [
+    "ATOM",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ATOM"
+      }
+    ]
+  ],
+  [
+    "AVAX_C",
+    [
+      {
+        "contractAddress": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "AVAX"
+      },
+      {
+        "contractAddress": "0xd1c3f94de7e5b45fa4edbba472491a9f4b166fc4",
+        "tokenCode": "XAVA"
+      },
+      {
+        "contractAddress": "0x8729438eb15e2c8b576fcc6aecda6a148776c0f5",
+        "tokenCode": "QI"
+      },
+      {
+        "contractAddress": "0x62edc0692bd897d2295872a9ffcac5425011c661",
+        "tokenCode": "GMX"
+      },
+      {
+        "contractAddress": "0x420fca0121dc28039145009570975747295f2329",
+        "tokenCode": "COQ"
+      },
+      {
+        "contractAddress": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
+        "tokenCode": "ZRO"
+      },
+      {
+        "contractAddress": "0x97f2624d5f99a953ae5574ea57d3268785941de4",
+        "tokenCode": "COLS"
+      },
+      {
+        "contractAddress": "0xb6314518b61b4864162c7ae7fdc36261e0a14c4b",
+        "tokenCode": "YOM"
+      }
+    ]
+  ],
+  [
+    "AXL",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "AXL"
+      }
+    ]
+  ],
+  [
+    "BASE",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ETH"
+      },
+      {
+        "contractAddress": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": "0xf43eb8de897fbc7f2502483b2bef7bb9ea179229",
+        "tokenCode": "ZEN"
+      },
+      {
+        "contractAddress": "0x43feb74608334dda8c1a6500d185cfc3ea962b83",
+        "tokenCode": "MOVR"
+      },
+      {
+        "contractAddress": "0xb3846fd356c2149ee8d30b0449088dc74e265459",
+        "tokenCode": "GLMR"
+      },
+      {
+        "contractAddress": "0xa88594d404727625a9437c3f886c7643872296ae",
+        "tokenCode": "WELL"
+      },
+      {
+        "contractAddress": "0x24fcFC492C1393274B6bcd568ac9e225BEc93584",
+        "tokenCode": "MAVIA"
+      },
+      {
+        "contractAddress": "0x940181a94a35a4569e4529a3cdfb74e38fd98631",
+        "tokenCode": "AERO"
+      },
+      {
+        "contractAddress": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+        "tokenCode": "DEGEN"
+      },
+      {
+        "contractAddress": "0x532f27101965dd16442e59d40670faf5ebb142e4",
+        "tokenCode": "BRETT"
+      },
+      {
+        "contractAddress": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
+        "tokenCode": "ZRO"
+      },
+      {
+        "contractAddress": "0x2Da56AcB9Ea78330f947bD57C54119Debda7AF71",
+        "tokenCode": "MOG"
+      },
+      {
+        "contractAddress": "0xc08cd26474722ce93f4d0c34d16201461c10aa8c",
+        "tokenCode": "CARV"
+      },
+      {
+        "contractAddress": "0xBAa5CC21fd487B8Fcc2F632f3F4E8D37262a0842",
+        "tokenCode": "MORPHO"
+      },
+      {
+        "contractAddress": "0xe2b1dc2d4a3b4e59fdf0c47b71a7a86391a8b35a",
+        "tokenCode": "RWA"
+      },
+      {
+        "contractAddress": "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b",
+        "tokenCode": "VIRTUAL"
+      },
+      {
+        "contractAddress": "0xac1bd2486aaf3b5c0fc3fd868558b082a531b2b4",
+        "tokenCode": "TOSHI"
+      },
+      {
+        "contractAddress": "0x2c24497d4086490e7ead87cc12597fb50c2e6ed6",
+        "tokenCode": "F"
+      },
+      {
+        "contractAddress": "0xfb42da273158b0f642f59f2ba7cc1d5457481677",
+        "tokenCode": "LINGO"
+      },
+      {
+        "contractAddress": "0x4f9fd6be4a90f2620860d680c0d4d5fb53d1a825",
+        "tokenCode": "AIXBT"
+      },
+      {
+        "contractAddress": "0x0c1dc73159e30c4b06170f2593d3118968a0dca5",
+        "tokenCode": "GPS"
+      },
+      {
+        "contractAddress": "0x514D8E8099286a13486Ef6C525C120f51C239B52",
+        "tokenCode": "OBT"
+      },
+      {
+        "contractAddress": "0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf",
+        "tokenCode": "VVV"
+      },
+      {
+        "contractAddress": "0x67543cf0304c19ca62ac95ba82fd4f4b40788dc1",
+        "tokenCode": "RIZ"
+      },
+      {
+        "contractAddress": "0x98d0baa52b2d063e780de12f615f963fe8537553",
+        "tokenCode": "KAITO"
+      },
+      {
+        "contractAddress": "0xb3b32f9f8827d4634fe7d973fa1034ec9fddb3b3",
+        "tokenCode": "B3"
+      },
+      {
+        "contractAddress": "0x30c7235866872213f68cb1f08c37cb9eccb93452",
+        "tokenCode": "PROMPT"
+      },
+      {
+        "contractAddress": "0x1111111111166b7fe7bd91427724b487980afc69",
+        "tokenCode": "ZORA"
+      },
+      {
+        "contractAddress": "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb",
+        "tokenCode": "CLANKER"
+      },
+      {
+        "contractAddress": "0xa2c22252cdc8b7cddee1b0b2e242818509fcf7b8",
+        "tokenCode": "SXT"
+      },
+      {
+        "contractAddress": "0x1b4617734c43f6159f3a70b7e06d883647512778",
+        "tokenCode": "AWE"
+      },
+      {
+        "contractAddress": "0x18dd5b087bca9920562aff7a0199b96b9230438b",
+        "tokenCode": "PRO"
+      },
+      {
+        "contractAddress": "0x5ab3d4c385b400f3abb49e80de2faf6a88a7b691",
+        "tokenCode": "FLOCK"
+      },
+      {
+        "contractAddress": "0x4bfaa776991e85e5f8b1255461cbbd216cfc714f",
+        "tokenCode": "HOME"
+      },
+      {
+        "contractAddress": "0xe0cd4cacddcbf4f36e845407ce53e87717b6601d",
+        "tokenCode": "ICNT"
+      },
+      {
+        "contractAddress": "0xba12bc7b210e61e5d3110b997a63ea216e0e18f7",
+        "tokenCode": "C"
+      },
+      {
+        "contractAddress": "0x00000000a22c618fd6b4d7e9a335c4b96b189a38",
+        "tokenCode": "TOWNS"
+      },
+      {
+        "contractAddress": "0xc729777d0470f30612b1564fd96e8dd26f5814e3",
+        "tokenCode": "SAPIEN"
+      },
+      {
+        "contractAddress": "0x4dec3139f4a6c638e26452d32181fe87a7530805",
+        "tokenCode": "ART"
+      },
+      {
+        "contractAddress": "0x696f9436b67233384889472cd7cd58a6fb5df4f1",
+        "tokenCode": "AVNT"
+      },
+      {
+        "contractAddress": "0x7aafd31a321d3627b30a8e2171264b56852187fe",
+        "tokenCode": "MIRA"
+      },
+      {
+        "contractAddress": "0x1f16e03c1a5908818f47f6ee7bb16690b40d0671",
+        "tokenCode": "RECALL"
+      },
+      {
+        "contractAddress": "0x9eadbe35f3ee3bf3e28180070c429298a1b02f93",
+        "tokenCode": "LMTS"
+      },
+      {
+        "contractAddress": "0x4c87da04887a1f9f21f777e3a8dd55c3c9f84701",
+        "tokenCode": "COMMON"
+      },
+      {
+        "contractAddress": "0x9215e6362f76fc781df00d51293cc7179c6c99a4",
+        "tokenCode": "PLAI"
+      },
+      {
+        "contractAddress": "0x6cd905df2ed214b22e0d48ff17cd4200c1c6d8a3",
+        "tokenCode": "TRUST"
+      },
+      {
+        "contractAddress": "0x853a7c99227499dba9db8c3a02aa691afdebf841",
+        "tokenCode": "PLAY"
+      },
+      {
+        "contractAddress": "0x0b2558bdbc7ffec0f327fb3579c23dabd1699706",
+        "tokenCode": "THQ"
+      },
+      {
+        "contractAddress": "0xd67ec255100ef200a439d09ff865fbaa2ad9c730",
+        "tokenCode": "SCOR"
+      },
+      {
+        "contractAddress": "0x16ee7ecac70d1028e7712751e2ee6ba808a7dd92",
+        "tokenCode": "FUN"
+      },
+      {
+        "contractAddress": "0x29cc30f9d113b356ce408667aa6433589cecbdca",
+        "tokenCode": "ELSA"
+      },
+      {
+        "contractAddress": "0xa53887f7e7c1bf5010b8627f1c1ba94fe7a5d6e0",
+        "tokenCode": "RNBW"
+      },
+      {
+        "contractAddress": "0x5b2193fdc451c1f847be09ca9d13a4bf60f8c86b",
+        "tokenCode": "UP"
+      },
+      {
+        "contractAddress": "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b",
+        "tokenCode": "BNKR"
+      },
+      {
+        "contractAddress": "0x499d35ebe6cee9b2ac35fd003fcbbeeb9cfc7b32",
+        "tokenCode": "ATWO"
+      },
+      {
+        "contractAddress": "0x940a319b75861014a220d9c6c144d108552b089b",
+        "tokenCode": "DEUS"
+      },
+      {
+        "contractAddress": "0x182fa643e5f29d5eca75e7b9cf9336a3fe4620b2",
+        "tokenCode": "O"
+      },
+      {
+        "contractAddress": "0x90eb0e291e9d78a96bfe423b8e616a02c4838cf0",
+        "tokenCode": "ILY"
+      },
+      {
+        "contractAddress": "0x624e2e7fDc8903165F64891672267AB0FCB98831",
+        "tokenCode": "SOSO"
+      },
+      {
+        "contractAddress": "0xFbC2051AE2265686a469421b2C5A2D5462FbF5eB",
+        "tokenCode": "OPG"
+      }
+    ]
+  ],
+  [
+    "BCH",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "BCH"
+      }
+    ]
+  ],
+  [
+    "BCHSV",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "BCHSV"
+      }
+    ]
+  ],
+  [
+    "BSC",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "BNB"
+      },
+      {
+        "contractAddress": "0xf486ad071f3bEE968384D2E39e2D8aF0fCf6fd46",
+        "tokenCode": "VELO"
+      },
+      {
+        "contractAddress": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
+        "tokenCode": "ETH"
+      },
+      {
+        "contractAddress": "0x55d398326f99059ff775485246999027b3197955",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": "0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82",
+        "tokenCode": "CAKE"
+      },
+      {
+        "contractAddress": "0x2859e4544c4bb03966803b044a93563bd2d0dd4d",
+        "tokenCode": "SHIB"
+      },
+      {
+        "contractAddress": "0x33d08d8c7a168333a85285a68c0042b39fc3741d",
+        "tokenCode": "AIOZ"
+      },
+      {
+        "contractAddress": "0xac51066d7bec65dc4589368da368b212745d63e8",
+        "tokenCode": "ALICE"
+      },
+      {
+        "contractAddress": "0x6e88056e8376ae7709496ba64d37fa2f8015ce3e",
+        "tokenCode": "DEXE"
+      },
+      {
+        "contractAddress": "0xaec945e04baf28b135fa7c640f624f8d90f1c3a6",
+        "tokenCode": "C98"
+      },
+      {
+        "contractAddress": "0x4b0f1812e5df2a09796481ff14017e6005508003",
+        "tokenCode": "TWT"
+      },
+      {
+        "contractAddress": "0xeceb87cf00dcbf2d4e2880223743ff087a995ad9",
+        "tokenCode": "NUM"
+      },
+      {
+        "contractAddress": "0xd41fdb03ba84762dd66a0af1a6c8540ff1ba5dfb",
+        "tokenCode": "SFP"
+      },
+      {
+        "contractAddress": "0x89af13a10b32f1b2f8d1588f93027f69b6f4e27e",
+        "tokenCode": "GAFI"
+      },
+      {
+        "contractAddress": "0x3019bf2a2ef8040c242c9a4c5c4bd4c81678b2a1",
+        "tokenCode": "GMT"
+      },
+      {
+        "contractAddress": "0x7324c7c0d95cebc73eea7e85cbaac0dbdf88a05b",
+        "tokenCode": "XCN"
+      },
+      {
+        "contractAddress": "0x287880ea252b52b63cc5f40a2d3e5a44aa665a76",
+        "tokenCode": "ALPINE"
+      },
+      {
+        "contractAddress": "0x8fff93e810a2edaafc326edee51071da9d398e83",
+        "tokenCode": "BRISE"
+      },
+      {
+        "contractAddress": "0xfb5b838b6cfeedc2873ab27866079ac55363d37e",
+        "tokenCode": "FLOKI"
+      },
+      {
+        "contractAddress": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
+        "tokenCode": "ID"
+      },
+      {
+        "contractAddress": "0x9840652dc04fb9db2c43853633f0f62be6f00f98",
+        "tokenCode": "CGPT"
+      },
+      {
+        "contractAddress": "0xc748673057861a797275cd8a068abb95a902e8de",
+        "tokenCode": "BABYDOGE"
+      },
+      {
+        "contractAddress": "0xdce40c14d5956f8b8ba912402ba73b4d4d599612",
+        "tokenCode": "PZP"
+      },
+      {
+        "contractAddress": "0x69a87c8788d4a48c1362b3b357d0e6b59c11d93f",
+        "tokenCode": "OBI"
+      },
+      {
+        "contractAddress": "0xbdeae1ca48894a1759a8374d63925f21f2ee2639",
+        "tokenCode": "EDU"
+      },
+      {
+        "contractAddress": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
+        "tokenCode": "TOKEN"
+      },
+      {
+        "contractAddress": "0x003d87d02a2a01e9e8a20f507c83e15dd83a33d1",
+        "tokenCode": "GTAI"
+      },
+      {
+        "contractAddress": "0x6d106c0b8d2f47c5465bdbd58d1be253762cbbc1",
+        "tokenCode": "DEFI"
+      },
+      {
+        "contractAddress": "0x998305efdc264b9674178899fffbb44a47134a76",
+        "tokenCode": "GMRX"
+      },
+      {
+        "contractAddress": "0x491e6de43b55c8eae702edc263e32339da42f58c",
+        "tokenCode": "ESE"
+      },
+      {
+        "contractAddress": "0x2b72867c32cf673f7b02d208b26889fed353b1f8",
+        "tokenCode": "SQR"
+      },
+      {
+        "contractAddress": "0xfebe8c1ed424dbf688551d4e2267e7a53698f0aa",
+        "tokenCode": "VINU"
+      },
+      {
+        "contractAddress": "0x94a8b4ee5cd64c79d0ee816f467ea73009f51aa0",
+        "tokenCode": "RIO"
+      },
+      {
+        "contractAddress": "0xc0041ef357b183448b235a8ea73ce4e4ec8c265f",
+        "tokenCode": "COOKIE"
+      },
+      {
+        "contractAddress": "0xfceb31a79f71ac9cbdcf853519c1b12d379edc46",
+        "tokenCode": "LISTA"
+      },
+      {
+        "contractAddress": "0x5f78f4bfcb2b43bc174fe16a69a13945cefa2978",
+        "tokenCode": "XR"
+      },
+      {
+        "contractAddress": "0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649",
+        "tokenCode": "G"
+      },
+      {
+        "contractAddress": "0x6894cde390a3f51155ea41ed24a33a4827d3063d",
+        "tokenCode": "CAT"
+      },
+      {
+        "contractAddress": "0xb994882a1b9bd98a71dd6ea5f61577c42848b0e8",
+        "tokenCode": "WOD"
+      },
+      {
+        "contractAddress": "0xc9cCbd76c2353e593Cc975F13295e8289d04D3Bb",
+        "tokenCode": "F"
+      },
+      {
+        "contractAddress": "0xff583dc5ddc7c0bb3625fff39a587a2000e78888",
+        "tokenCode": "HOLD"
+      },
+      {
+        "contractAddress": "0xd5eaaac47bd1993d661bc087e15dfb079a7f3c19",
+        "tokenCode": "KOMA"
+      },
+      {
+        "contractAddress": "0x49f1d4db3ea1a64390e990c6debeac88eac007ca",
+        "tokenCode": "ITHACA"
+      },
+      {
+        "contractAddress": "0x103071da56e7cd95b415320760d6a0ddc4da1ca5",
+        "tokenCode": "XTER"
+      },
+      {
+        "contractAddress": "0x9a4a67721573f2c9209dfff972c52be4e3f6642e",
+        "tokenCode": "GPS"
+      },
+      {
+        "contractAddress": "0xabe8e5cabe24cb36df9540088fd7ce1175b9bc52",
+        "tokenCode": "SOLV"
+      },
+      {
+        "contractAddress": "0x8263cd1601fe73c066bf49cc09841f35348e3be0",
+        "tokenCode": "ALU"
+      },
+      {
+        "contractAddress": "0x8fb238058e71f828f505582e65b1d14f8cf52067",
+        "tokenCode": "D"
+      },
+      {
+        "contractAddress": "0x0df0587216a4a1bb7d5082fdc491d93d2dd4b413",
+        "tokenCode": "CHEEMS"
+      },
+      {
+        "contractAddress": "0x86bb94ddd16efc8bc58e6b056e8df71d9e666429",
+        "tokenCode": "TSTBSC"
+      },
+      {
+        "contractAddress": "0x3ab1a5f76e12202d1ad1548a08a799501581da4e",
+        "tokenCode": "DIN"
+      },
+      {
+        "contractAddress": "0xf2c88757f8d03634671208935974b60a2a28bdb3",
+        "tokenCode": "SHELL"
+      },
+      {
+        "contractAddress": "0x5c85d6c6825ab4032337f11ee92a72df936b46f6",
+        "tokenCode": "MUBARAK"
+      },
+      {
+        "contractAddress": "0x7d814b9ed370ec0a502edc3267393bf62d891b62",
+        "tokenCode": "BMT"
+      },
+      {
+        "contractAddress": "0xcaae2a2f939f51d97cdfa9a86e79e3f085b799f3",
+        "tokenCode": "TUT"
+      },
+      {
+        "contractAddress": "0xff7d6a96ae471bbcd7713af9cb1feeb16cf56b41",
+        "tokenCode": "BR"
+      },
+      {
+        "contractAddress": "0x59264f02d301281f3393e1385c0aefd446eb0f00",
+        "tokenCode": "PARTI"
+      },
+      {
+        "contractAddress": "0xdaf1695c41327b61b9b9965ac6a5843a3198cf07",
+        "tokenCode": "STO"
+      },
+      {
+        "contractAddress": "0xc9d23ed2adb0f551369946bd377f8644ce1ca5c4",
+        "tokenCode": "HYPER"
+      },
+      {
+        "contractAddress": "0x868fced65edbf0056c4163515dd840e9f287a4c3",
+        "tokenCode": "SIGN"
+      },
+      {
+        "contractAddress": "0xf2b51cc1850fed939658317a22d73d3482767591",
+        "tokenCode": "NXPC"
+      },
+      {
+        "contractAddress": "0x899357e54c2c4b014ea50a9a7bf140ba6df2ec73",
+        "tokenCode": "PRAI"
+      },
+      {
+        "contractAddress": "0x5dbde81fce337ff4bcaaee4ca3466c00aecae274",
+        "tokenCode": "AGT"
+      },
+      {
+        "contractAddress": "0xb9e1fd5a02d3a33b25a14d661414e6ed6954a721",
+        "tokenCode": "SOON"
+      },
+      {
+        "contractAddress": "0x4BfAa776991E85e5f8b1255461cbbd216cFc714f",
+        "tokenCode": "HOME"
+      },
+      {
+        "contractAddress": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
+        "tokenCode": "GOMINING"
+      },
+      {
+        "contractAddress": "0xaff2e841851700d1fc101995ee6b81ae21bb87d7",
+        "tokenCode": "SPK"
+      },
+      {
+        "contractAddress": "0xbfe78de7d1c51e0868501d5fa3e88e674c79acdd",
+        "tokenCode": "LOT"
+      },
+      {
+        "contractAddress": "0x0c78d4605c2972e5f989de9019de1fb00c5d3462",
+        "tokenCode": "CESS"
+      },
+      {
+        "contractAddress": "0x6bf62ca91e397b5a7d1d6bce97d9092065d7a510",
+        "tokenCode": "CROSS"
+      },
+      {
+        "contractAddress": "0x9558a9254890b2a8b057a789f413631b9084f4a3",
+        "tokenCode": "AIN"
+      },
+      {
+        "contractAddress": "0x8b194370825e37b33373e74a41009161808c1488",
+        "tokenCode": "VELVET"
+      },
+      {
+        "contractAddress": "0xc0c240c870606a5cb3150795e2d0dfff9f1f7456",
+        "tokenCode": "RION"
+      },
+      {
+        "contractAddress": "0xad8c787992428cd158e451aab109f724b6bc36de",
+        "tokenCode": "ASP"
+      },
+      {
+        "contractAddress": "0xe3225e11cab122f1a126a28997788e5230838ab9",
+        "tokenCode": "XNY"
+      },
+      {
+        "contractAddress": "0x81a7da4074b8e0ed51bea40f9dcbdf4d9d4832b4",
+        "tokenCode": "AIO"
+      },
+      {
+        "contractAddress": "0x19ed254efa5e061d28d84650891a3db2a9940c16",
+        "tokenCode": "SUP"
+      },
+      {
+        "contractAddress": "0x7DDf164CEcfddd0f992299D033B5a11279A15929",
+        "tokenCode": "PROVE"
+      },
+      {
+        "contractAddress": "0xf4b385849f2e817e92bffbfb9aeb48f950ff4444",
+        "tokenCode": "EGL1"
+      },
+      {
+        "contractAddress": "0x2c3a8ee94ddd97244a93bc48298f97d2c412f7db",
+        "tokenCode": "AKE"
+      },
+      {
+        "contractAddress": "0x0f0df6cb17ee5e883eddfef9153fc6036bdb4e37",
+        "tokenCode": "BAS"
+      },
+      {
+        "contractAddress": "0xd955c9ba56fb1ab30e34766e252a97ccce3d31a6",
+        "tokenCode": "XPIN"
+      },
+      {
+        "contractAddress": "0xc07e1300dc138601fa6b0b59f8d0fa477e690589",
+        "tokenCode": "Q"
+      },
+      {
+        "contractAddress": "0xa9616e5e23EC1582c2828B025bEcf3Ef610e266F",
+        "tokenCode": "SOMI"
+      },
+      {
+        "contractAddress": "0xa3cfb853339b77f385b994799b015cb04b208fe6",
+        "tokenCode": "POP"
+      },
+      {
+        "contractAddress": "0x1a5d7e4c3a7f940b240b7357a4bfed30d17f9497",
+        "tokenCode": "HOLO"
+      },
+      {
+        "contractAddress": "0x40b8129b786d766267a7a118cf8c07e31cdb6fde",
+        "tokenCode": "UB"
+      },
+      {
+        "contractAddress": "0x15247e6e23d3923a853ccf15940a20ccdf16e94a",
+        "tokenCode": "ZKC"
+      },
+      {
+        "contractAddress": "0xc61eb549acf4a05ed6e3fe0966f5e213b23541ce",
+        "tokenCode": "NUMI"
+      },
+      {
+        "contractAddress": "0xa890f8ba60051ec8a5b528f056da362ba208a96f",
+        "tokenCode": "GAIN"
+      },
+      {
+        "contractAddress": "0x000ae314e2a2172a039b26378814c252734f556a",
+        "tokenCode": "ASTER"
+      },
+      {
+        "contractAddress": "0x8dedf84656fa932157e27c060d8613824e7979e3",
+        "tokenCode": "STBL"
+      },
+      {
+        "contractAddress": "0x6261963ebe9ff014aad10ecc3b0238d4d04e8353",
+        "tokenCode": "HANA"
+      },
+      {
+        "contractAddress": "0x477c2c0459004e3354ba427fa285d7c053203c0e",
+        "tokenCode": "LIGHT"
+      },
+      {
+        "contractAddress": "0x302dfaf2cdbe51a18d97186a7384e87cf599877d",
+        "tokenCode": "LYN"
+      },
+      {
+        "contractAddress": "0x76e9b54b49739837be8ad10c3687fc6b543de852",
+        "tokenCode": "KLINK"
+      },
+      {
+        "contractAddress": "0x20d6015660b3fe52e6690a889b5c51f69902ce0e",
+        "tokenCode": "GIGGLE"
+      },
+      {
+        "contractAddress": "0x81d3a238b02827f62b9f390f947d36d4a5bf89d2",
+        "tokenCode": "CLO"
+      },
+      {
+        "contractAddress": "0x7ec43cf65f1663f820427c62a5780b8f2e25593a",
+        "tokenCode": "LAB"
+      },
+      {
+        "contractAddress": "0x6bc3855827fa6ee1229c937a26bb9fca1a0ffbf0",
+        "tokenCode": "ANOME"
+      },
+      {
+        "contractAddress": "0xfeB339236d25D3E415F280189bC7C2FBAb6ae9ef",
+        "tokenCode": "ENSO"
+      },
+      {
+        "contractAddress": "0x635d44f246156ed1080cb470877256c847673f19",
+        "tokenCode": "WBAI"
+      },
+      {
+        "contractAddress": "0xfab99fcf605fd8f4593edb70a43ba56542777777",
+        "tokenCode": "ZBT"
+      },
+      {
+        "contractAddress": "0xed9ae3def8d6f052971bb8b6d1975ff267cf9aad",
+        "tokenCode": "BLUAI"
+      },
+      {
+        "contractAddress": "0x46345336e7c5c89bd15d557203040f2c1ab4dd18",
+        "tokenCode": "PIGGY"
+      },
+      {
+        "contractAddress": "0xcf3232b85b43bca90e51d38cc06cc8bb8c8a3e36",
+        "tokenCode": "BEAT"
+      },
+      {
+        "contractAddress": "0x3e5d4f8aee0d9b3082d5f6da5d6e225d17ba9ea0",
+        "tokenCode": "UAI"
+      },
+      {
+        "contractAddress": "0xff7f8f301f7a706e3cfd3d2275f5dc0b9ee8009b",
+        "tokenCode": "FOLKS"
+      },
+      {
+        "contractAddress": "0x299ad4299da5b2b93fba4c96967b040c7f611099",
+        "tokenCode": "APR"
+      },
+      {
+        "contractAddress": "0xea37a8de1de2d9d10772eeb569e28bfa5cb17707",
+        "tokenCode": "JCT"
+      },
+      {
+        "contractAddress": "0xFe930c2d63AeD9b82fC4DBC801920dD2c1a3224F",
+        "tokenCode": "NIGHT"
+      },
+      {
+        "contractAddress": "0x0c69199c1562233640e0db5ce2c399a88eb507c7",
+        "tokenCode": "CYS"
+      },
+      {
+        "contractAddress": "0x876cecb73c9ed1b1526f8e35c6a5a51a31bcf341",
+        "tokenCode": "VOOI"
+      },
+      {
+        "contractAddress": "0x7765a659c5b0cfbfd9fbc2ef2298b75a598f2d2d",
+        "tokenCode": "ESIM"
+      },
+      {
+        "contractAddress": "0x9b6a1d4fa5d90e5f2d34130053978d14cd301d58",
+        "tokenCode": "DN"
+      },
+      {
+        "contractAddress": "0x924fa68a0fc644485b8df8abfa0a41c2e7744444",
+        "tokenCode": "BNRENSHENG"
+      },
+      {
+        "contractAddress": "0xB2D97C4ed2d0Ef452654F5CAB3da3735B5e6F3ab",
+        "tokenCode": "FIGHT"
+      },
+      {
+        "contractAddress": "0x6db461da03b8ad06319ff2af985e1c8dfcc004e0",
+        "tokenCode": "GF"
+      },
+      {
+        "contractAddress": "0xf758cfb1467a227516d73d87da7d36e7cb6f71f1",
+        "tokenCode": "SN3"
+      },
+      {
+        "contractAddress": "0x23ae4fd8e7844cdbc97775496ebd0e8248656028",
+        "tokenCode": "XAUM"
+      },
+      {
+        "contractAddress": "0xe1ab61f7b093435204df32f5b3a405de55445ea8",
+        "tokenCode": "ION"
+      },
+      {
+        "contractAddress": "0x8aab31fbc69c92fa53f600910cf0f215531f8239",
+        "tokenCode": "WL"
+      },
+      {
+        "contractAddress": "0x97693439ea2f0ecdeb9135881e49f354656a911c",
+        "tokenCode": "RAVE"
+      },
+      {
+        "contractAddress": "0x1f12b85aac097e43aa1555b2881e98a51090e9a6",
+        "tokenCode": "GENIUS"
+      },
+      {
+        "contractAddress": "0x5fca51aff213bfbeab0b711b93c3374252fd6ac3",
+        "tokenCode": "SHARE"
+      },
+      {
+        "contractAddress": "0xae7484d162ba80b340eba7769a7a67838b1c16c1",
+        "tokenCode": "NXT"
+      },
+      {
+        "contractAddress": "0x777bf78ad4546b61607a17bf4a1977dbbea98c28",
+        "tokenCode": "BABYSHARK"
+      },
+      {
+        "contractAddress": "0x5506599c722389a60580b5213ea1da60d64754a1",
+        "tokenCode": "ZEST"
+      },
+      {
+        "contractAddress": "0x0E63B9C287E32A05E6b9AB8ee8dF88A2760225A9",
+        "tokenCode": "PIEVERSE"
+      },
+      {
+        "contractAddress": "0xf39e4b21c84e737df08e2c3b32541d856f508e48",
+        "tokenCode": "ESPORTS"
+      },
+      {
+        "contractAddress": "0x4d41a5d412f4ef44a35b9f53b06db65ede249493",
+        "tokenCode": "QAIT"
+      },
+      {
+        "contractAddress": "0xce24439f2d9c6a2289f741120fe202248b666666",
+        "tokenCode": "U"
+      },
+      {
+        "contractAddress": "0x44fc58faaaca03e5d52e493dae930ffa63e2a664",
+        "tokenCode": "UMXM"
+      },
+      {
+        "contractAddress": "0x3131f6b80c26936ab03f7d9d29eb4ddf36ac3fb5",
+        "tokenCode": "NES"
+      },
+      {
+        "contractAddress": "0x3aee7602b612de36088f3ffed8c8f10e86ebf2bf",
+        "tokenCode": "BANK"
+      },
+      {
+        "contractAddress": "0x208bf3e7da9639f1eaefa2de78c23396b0682025",
+        "tokenCode": "TAG"
+      },
+      {
+        "contractAddress": "0x277add739c6e0477616948357af9e79fe1ec9b80",
+        "tokenCode": "AEON"
+      },
+      {
+        "contractAddress": "0xEEC6574eAbBa52bac3f0277F2cD5Ac7e67197886",
+        "tokenCode": "KII"
+      },
+      {
+        "contractAddress": "0x8443f091997f06a61670b735ed92734f5628692f",
+        "tokenCode": "BEL"
+      },
+      {
+        "contractAddress": "0x4b8285aB433D8f69CB48d5Ad62b415ed1a221e4f",
+        "tokenCode": "MCRT"
+      },
+      {
+        "contractAddress": "0x9BeEE89723cEeC27d7c2834bec6834208FFdc202",
+        "tokenCode": "AVL"
+      },
+      {
+        "contractAddress": "0x1FA0f5ed24a1a2b43741E88F8FEc19633e67082B",
+        "tokenCode": "DIAM"
+      },
+      {
+        "contractAddress": "0xd55C9fB62E176a8Eb6968f32958FeFDD0962727E",
+        "tokenCode": "FHE"
+      },
+      {
+        "contractAddress": "0xC1353D3Ee02FDbd4f65F92EEe543cfd709049CB1",
+        "tokenCode": "CUDIS"
+      },
+      {
+        "contractAddress": "0x539AE81A166E5E80aEd211731563e549c411b140",
+        "tokenCode": "TA"
+      },
+      {
+        "contractAddress": "0xC19D38925F9F645337B1D1f37bAf3C0647A48E50",
+        "tokenCode": "GAIB"
+      },
+      {
+        "contractAddress": "0x595dEaad1eB5476Ff1E649fDb7EFC36F1E4679cc",
+        "tokenCode": "BSB"
+      },
+      {
+        "contractAddress": "0x7977BF3e7e0c954D12cdcA3E013ADAf57E0B06E0",
+        "tokenCode": "OPN"
+      }
+    ]
+  ],
+  [
+    "BTC",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "BTC"
+      },
+      {
+        "contractAddress": "ordi",
+        "tokenCode": "ORDI"
+      },
+      {
+        "contractAddress": "sats",
+        "tokenCode": "SATS"
+      },
+      {
+        "contractAddress": "rats",
+        "tokenCode": "RATS"
+      }
+    ]
+  ],
+  [
+    "CELO",
+    [
+      {
+        "contractAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "CELO"
+      }
+    ]
+  ],
+  [
+    "DASH",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "DASH"
+      }
+    ]
+  ],
+  [
+    "DGB",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "DGB"
+      }
+    ]
+  ],
+  [
+    "DOGE",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "DOGE"
+      }
+    ]
+  ],
+  [
+    "DOT",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "DOT"
+      },
+      {
+        "contractAddress": "1984",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "1337",
+        "tokenCode": "USDC"
+      }
+    ]
+  ],
+  [
+    "EOS",
+    [
+      {
+        "contractAddress": "core.vaulta",
+        "tokenCode": "A"
+      }
+    ]
+  ],
+  [
+    "ETC",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ETC"
+      }
+    ]
+  ],
+  [
+    "ETH",
+    [
+      {
+        "contractAddress": "0xa6c0c097741d55ecd9a3a7def3a8253fd022ceb9",
+        "tokenCode": "AVA"
+      },
+      {
+        "contractAddress": "0x6226e00bcac68b0fe55583b90a1d727c14fab77f",
+        "tokenCode": "MTV"
+      },
+      {
+        "contractAddress": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+        "tokenCode": "TEL"
+      },
+      {
+        "contractAddress": "0x8a2279d4a90b6fe1c4b30fa660cc9f926797baa2",
+        "tokenCode": "CHR"
+      },
+      {
+        "contractAddress": "0xba50933c268f567bdc86e1ac131be072c6b0b71a",
+        "tokenCode": "ARPA"
+      },
+      {
+        "contractAddress": "0x3506424f91fd33084466f402d5d97f05f8e3b4af",
+        "tokenCode": "CHZ"
+      },
+      {
+        "contractAddress": "0xc19b6a4ac7c7cc24459f08984bbd09664af17bd1",
+        "tokenCode": "SENSO"
+      },
+      {
+        "contractAddress": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+        "tokenCode": "COMP"
+      },
+      {
+        "contractAddress": "0x0763fdccf1ae541a5961815c0872a8c5bc6de4d7",
+        "tokenCode": "SUKU"
+      },
+      {
+        "contractAddress": "0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419",
+        "tokenCode": "DIA"
+      },
+      {
+        "contractAddress": "0x514910771af9ca656af840dff83e8264ecf986ca",
+        "tokenCode": "LINK"
+      },
+      {
+        "contractAddress": "0xb66a5d30d04f076e78ffb0d045c55846fdcde928",
+        "tokenCode": "EWT"
+      },
+      {
+        "contractAddress": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+        "tokenCode": "UMA"
+      },
+      {
+        "contractAddress": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
+        "tokenCode": "ALEPH"
+      },
+      {
+        "contractAddress": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+        "tokenCode": "YFI"
+      },
+      {
+        "contractAddress": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+        "tokenCode": "UNI"
+      },
+      {
+        "contractAddress": "0xd13c7342e1ef687c5ad21b27c2b65d772cab5c8c",
+        "tokenCode": "UOS"
+      },
+      {
+        "contractAddress": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+        "tokenCode": "AAVE"
+      },
+      {
+        "contractAddress": "0xf34960d9d60be18cc1d5afc1a6f012a723a28811",
+        "tokenCode": "KCS"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "ETH"
+      },
+      {
+        "contractAddress": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+        "tokenCode": "SNX"
+      },
+      {
+        "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "0x192675d1e131b9e339f16603e21b01a845d8c21e",
+        "tokenCode": "SHR"
+      },
+      {
+        "contractAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+        "tokenCode": "GRT"
+      },
+      {
+        "contractAddress": "0x111111111117dc0aa78b770fa6a738034120c302",
+        "tokenCode": "1INCH"
+      },
+      {
+        "contractAddress": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
+        "tokenCode": "API3"
+      },
+      {
+        "contractAddress": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+        "tokenCode": "CRV"
+      },
+      {
+        "contractAddress": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+        "tokenCode": "SUSHI"
+      },
+      {
+        "contractAddress": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+        "tokenCode": "LRC"
+      },
+      {
+        "contractAddress": "0x4a220e6096b25eadb88358cb44068a3248254675",
+        "tokenCode": "QNT"
+      },
+      {
+        "contractAddress": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+        "tokenCode": "BAT"
+      },
+      {
+        "contractAddress": "0x0f51bb10119727a7e5ea3538074fb341f56b09ad",
+        "tokenCode": "DAO"
+      },
+      {
+        "contractAddress": "0x69af81e73a73b40adf4f3d4223cd9b1ece623074",
+        "tokenCode": "MASK"
+      },
+      {
+        "contractAddress": "0x6c5ba91642f10282b576d91922ae6448c9d52f4e",
+        "tokenCode": "PHA"
+      },
+      {
+        "contractAddress": "0x464ebe77c293e473b48cfe96ddcf88fcf7bfdac0",
+        "tokenCode": "KRL"
+      },
+      {
+        "contractAddress": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+        "tokenCode": "MANA"
+      },
+      {
+        "contractAddress": "0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa",
+        "tokenCode": "ORBS"
+      },
+      {
+        "contractAddress": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
+        "tokenCode": "ANKR"
+      },
+      {
+        "contractAddress": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+        "tokenCode": "SAND"
+      },
+      {
+        "contractAddress": "0xd13cfd3133239a3c73a9e535a5c4dadee36b395c",
+        "tokenCode": "VAI"
+      },
+      {
+        "contractAddress": "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd",
+        "tokenCode": "DODO"
+      },
+      {
+        "contractAddress": "0xc477d038d5420c6a9e0b031712f61c5120090de9",
+        "tokenCode": "BOSON"
+      },
+      {
+        "contractAddress": "0x0fd10b9899882a6f2fcb5c371e17e70fdee00c38",
+        "tokenCode": "PUNDIX"
+      },
+      {
+        "contractAddress": "0x2a79324c19ef2b89ea98b23bc669b7e7c9f8a517",
+        "tokenCode": "WAX"
+      },
+      {
+        "contractAddress": "0x77fba179c79de5b7653f68b5039af940ada60ce0",
+        "tokenCode": "FORTH"
+      },
+      {
+        "contractAddress": "0x728f30fa2f100742c7949d1961804fa8e0b1387d",
+        "tokenCode": "GHX"
+      },
+      {
+        "contractAddress": "0x1c9922314ed1415c95b9fd453c3818fd41867d0b",
+        "tokenCode": "TOWER"
+      },
+      {
+        "contractAddress": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+        "tokenCode": "SHIB"
+      },
+      {
+        "contractAddress": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
+        "tokenCode": "OGN"
+      },
+      {
+        "contractAddress": "0x193f4a4a6ea24102f49b931deeeb931f6e32405d",
+        "tokenCode": "TLOS"
+      },
+      {
+        "contractAddress": "0x430ef9263e76dae63c84292c3409d61c598e9682",
+        "tokenCode": "PYR"
+      },
+      {
+        "contractAddress": "0xfc82bb4ba86045af6f327323a46e80412b91b27d",
+        "tokenCode": "PROM"
+      },
+      {
+        "contractAddress": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
+        "tokenCode": "ELON"
+      },
+      {
+        "contractAddress": "0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa",
+        "tokenCode": "POLS"
+      },
+      {
+        "contractAddress": "0xd9016a907dc0ecfa3ca425ab20b6b785b42f2373",
+        "tokenCode": "GMEE"
+      },
+      {
+        "contractAddress": "0x58b6a8a3302369daec383334672404ee733ab239",
+        "tokenCode": "LPT"
+      },
+      {
+        "contractAddress": "0xcccccccccc33d538dbc2ee4feab0a7a1ff4e8a94",
+        "tokenCode": "CFG"
+      },
+      {
+        "contractAddress": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+        "tokenCode": "AXS"
+      },
+      {
+        "contractAddress": "0x60f67e1015b3f069dd4358a78c38f83fe3a667a9",
+        "tokenCode": "ROUTE"
+      },
+      {
+        "contractAddress": "0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25",
+        "tokenCode": "SLP"
+      },
+      {
+        "contractAddress": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
+        "tokenCode": "GALAX"
+      },
+      {
+        "contractAddress": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
+        "tokenCode": "REQ"
+      },
+      {
+        "contractAddress": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
+        "tokenCode": "WOO"
+      },
+      {
+        "contractAddress": "0x2a3bff78b79a009976eea096a51a948a3dc00e34",
+        "tokenCode": "WILD"
+      },
+      {
+        "contractAddress": "0xba100000625a3754423978a60c9317c58a424e3d",
+        "tokenCode": "BAL"
+      },
+      {
+        "contractAddress": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
+        "tokenCode": "STORJ"
+      },
+      {
+        "contractAddress": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+        "tokenCode": "YGG"
+      },
+      {
+        "contractAddress": "0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7",
+        "tokenCode": "SKL"
+      },
+      {
+        "contractAddress": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+        "tokenCode": "NMR"
+      },
+      {
+        "contractAddress": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+        "tokenCode": "TRB"
+      },
+      {
+        "contractAddress": "0x55296f69f40ea6d20e478533c15a6b08b654e758",
+        "tokenCode": "XYO"
+      },
+      {
+        "contractAddress": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+        "tokenCode": "GTC"
+      },
+      {
+        "contractAddress": "0x607f4c5bb672230e8672085532f7e901544a7375",
+        "tokenCode": "RLC"
+      },
+      {
+        "contractAddress": "0x51cb253744189f11241becb29bedd3f1b5384fdb",
+        "tokenCode": "DMTR"
+      },
+      {
+        "contractAddress": "0x491604c0fdf08347dd1fa4ee062a822a5dd06b5d",
+        "tokenCode": "CTSI"
+      },
+      {
+        "contractAddress": "0xac51066d7bec65dc4589368da368b212745d63e8",
+        "tokenCode": "ALICE"
+      },
+      {
+        "contractAddress": "0x767fe9edc9e0df98e07454847909b5e959d7ca0e",
+        "tokenCode": "ILV"
+      },
+      {
+        "contractAddress": "0xba11d00c5f74255f56a5e366f4f77f5a186d7f55",
+        "tokenCode": "BAND"
+      },
+      {
+        "contractAddress": "0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9",
+        "tokenCode": "FTT"
+      },
+      {
+        "contractAddress": "0xae12c5930881c53715b369cec7606b70d8eb229f",
+        "tokenCode": "C98"
+      },
+      {
+        "contractAddress": "0xf418588522d5dd018b425e472991e52ebbeeeeee",
+        "tokenCode": "PUSH"
+      },
+      {
+        "contractAddress": "0x32353a6c91143bfd6c7d363b546e62a9a2489a20",
+        "tokenCode": "AGLD"
+      },
+      {
+        "contractAddress": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
+        "tokenCode": "INJ"
+      },
+      {
+        "contractAddress": "0x7420b4b9a0110cdc71fb720908340c03f9bc03ec",
+        "tokenCode": "JASMY"
+      },
+      {
+        "contractAddress": "0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55",
+        "tokenCode": "SUPER"
+      },
+      {
+        "contractAddress": "0x66761fa41377003622aee3c7675fc7b5c1c2fac5",
+        "tokenCode": "CPOOL"
+      },
+      {
+        "contractAddress": "0x2da719db753dfa10a62e140f436e1d67f2ddb0d6",
+        "tokenCode": "CERE"
+      },
+      {
+        "contractAddress": "0x45804880de22913dafe09f4980848ece6ecbaf78",
+        "tokenCode": "PAXG"
+      },
+      {
+        "contractAddress": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+        "tokenCode": "AUDIO"
+      },
+      {
+        "contractAddress": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+        "tokenCode": "ENS"
+      },
+      {
+        "contractAddress": "0xa2120b9e674d3fc3875f415a7df52e382f141225",
+        "tokenCode": "ATA"
+      },
+      {
+        "contractAddress": "0xade00c28244d5ce17d72e40330b1c318cd12b7c3",
+        "tokenCode": "ADX"
+      },
+      {
+        "contractAddress": "0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429",
+        "tokenCode": "GLM"
+      },
+      {
+        "contractAddress": "0x6e5970dbd6fc7eb1f29c6d2edf2bc4c36124c0c1",
+        "tokenCode": "TRADE"
+      },
+      {
+        "contractAddress": "0x320623b8e4ff03373931769a31fc52a4e78b5d70",
+        "tokenCode": "RSR"
+      },
+      {
+        "contractAddress": "0xf57e7e7c23978c3caec3c3548e3d615c346e79ff",
+        "tokenCode": "IMX"
+      },
+      {
+        "contractAddress": "0xccc8cb5229b0ac8069c51fd58367fd1e622afd97",
+        "tokenCode": "GODS"
+      },
+      {
+        "contractAddress": "0x57b946008913b82e4df85f501cbaed910e58d26c",
+        "tokenCode": "POND"
+      },
+      {
+        "contractAddress": "0x7d5121505149065b562c789a0145ed750e6e8cdd",
+        "tokenCode": "VR"
+      },
+      {
+        "contractAddress": "0xae6e307c3fe9e922e5674dbd7f830ed49c014c6b",
+        "tokenCode": "CREDI"
+      },
+      {
+        "contractAddress": "0xd47bdf574b4f76210ed503e0efe81b58aa061f3d",
+        "tokenCode": "TRVL"
+      },
+      {
+        "contractAddress": "0x8fac8031e079f409135766c7d5de29cf22ef897c",
+        "tokenCode": "HEART"
+      },
+      {
+        "contractAddress": "0x7a58c0be72be218b41c608b7fe7c5bb630736c71",
+        "tokenCode": "PEOPLE"
+      },
+      {
+        "contractAddress": "0x505b5eda5e25a67e1c24a2bf1a527ed9eb88bf04",
+        "tokenCode": "CWEB"
+      },
+      {
+        "contractAddress": "0xa3ee21c306a700e682abcdfe9baa6a08f3820419",
+        "tokenCode": "CTC"
+      },
+      {
+        "contractAddress": "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b",
+        "tokenCode": "CVX"
+      },
+      {
+        "contractAddress": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
+        "tokenCode": "AMP"
+      },
+      {
+        "contractAddress": "0x4d224452801aced8b2f0aebe155379bb5d594381",
+        "tokenCode": "APE"
+      },
+      {
+        "contractAddress": "0xe3c408BD53c31C085a1746AF401A4042954ff740",
+        "tokenCode": "GMT"
+      },
+      {
+        "contractAddress": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+        "tokenCode": "BICO"
+      },
+      {
+        "contractAddress": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+        "tokenCode": "STG"
+      },
+      {
+        "contractAddress": "0xa2cd3d43c775978a96bdbf12d733d5a1ed94fb18",
+        "tokenCode": "XCN"
+      },
+      {
+        "contractAddress": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+        "tokenCode": "T"
+      },
+      {
+        "contractAddress": "0x525a8f6f3ba4752868cde25164382bfbae3990e1",
+        "tokenCode": "NYM"
+      },
+      {
+        "contractAddress": "0xb4a3b0faf0ab53df58001804dda5bfc6a3d59008",
+        "tokenCode": "SPA"
+      },
+      {
+        "contractAddress": "0x0bb217e40f8a5cb79adf04e1aab60e5abd0dfc1e",
+        "tokenCode": "SWFTC"
+      },
+      {
+        "contractAddress": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
+        "tokenCode": "CELR"
+      },
+      {
+        "contractAddress": "0xAaAAAA20D9E0e2461697782ef11675f668207961",
+        "tokenCode": "AURORA"
+      },
+      {
+        "contractAddress": "0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202",
+        "tokenCode": "KNC"
+      },
+      {
+        "contractAddress": "0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697",
+        "tokenCode": "OVR"
+      },
+      {
+        "contractAddress": "0x42bbfa2e77757c645eeaad1655e0911a7553efbc",
+        "tokenCode": "BOBA"
+      },
+      {
+        "contractAddress": "0x0c7d5ae016f806603cb1782bea29ac69471cab9c",
+        "tokenCode": "BFC"
+      },
+      {
+        "contractAddress": "0x940a2db1b7008b6c776d4faaca729d6d4a4aa551",
+        "tokenCode": "DUSK"
+      },
+      {
+        "contractAddress": "0x4f8e5de400de08b164e7421b3ee387f461becd1a",
+        "tokenCode": "USDD"
+      },
+      {
+        "contractAddress": "0xed04915c23f00a313a544955524eb7dbd823143d",
+        "tokenCode": "ACH"
+      },
+      {
+        "contractAddress": "0x41545f8b9472d758bb669ed8eaeeecd7a9c4ec29",
+        "tokenCode": "FORT"
+      },
+      {
+        "contractAddress": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
+        "tokenCode": "USDP"
+      },
+      {
+        "contractAddress": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+        "tokenCode": "LDO"
+      },
+      {
+        "contractAddress": "0xd9fcd98c322942075a5c3860693e9f4f03aae07b",
+        "tokenCode": "EUL"
+      },
+      {
+        "contractAddress": "0xb3999f658c0391d94a37f7ff328f3fec942bcadc",
+        "tokenCode": "HFT"
+      },
+      {
+        "contractAddress": "0xfc1c93a2507975e98b9d0e9260ded61a00152bf1",
+        "tokenCode": "NAVI"
+      },
+      {
+        "contractAddress": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "tokenCode": "RPL"
+      },
+      {
+        "contractAddress": "0x71ab77b7dbb4fa7e017bc15090b2163221420282",
+        "tokenCode": "HIGH"
+      },
+      {
+        "contractAddress": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+        "tokenCode": "TRAC"
+      },
+      {
+        "contractAddress": "0x5283d291dbcf85356a21ba090e6db59121208b44",
+        "tokenCode": "BLUR"
+      },
+      {
+        "contractAddress": "0x467719ad09025fcc6cf6f8311755809d45a5e5f3",
+        "tokenCode": "WAXL"
+      },
+      {
+        "contractAddress": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
+        "tokenCode": "FLOKI"
+      },
+      {
+        "contractAddress": "0x9d65ff81a3c488d585bbfb0bfe3c7707c7917f54",
+        "tokenCode": "SSV"
+      },
+      {
+        "contractAddress": "0xaea46a60368a7bd060eec7df8cba43b7ef41ad85",
+        "tokenCode": "FET"
+      },
+      {
+        "contractAddress": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
+        "tokenCode": "SYN"
+      },
+      {
+        "contractAddress": "0x5732046a883704404f284ce41ffadd5b007fd668",
+        "tokenCode": "BLZ"
+      },
+      {
+        "contractAddress": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+        "tokenCode": "LQTY"
+      },
+      {
+        "contractAddress": "0x2dff88a56767223a5529ea5960da7a3f5f766406",
+        "tokenCode": "ID"
+      },
+      {
+        "contractAddress": "0xb50721bcf8d664c30412cfbc6cf7a15145234ad1",
+        "tokenCode": "ARB"
+      },
+      {
+        "contractAddress": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+        "tokenCode": "SD"
+      },
+      {
+        "contractAddress": "0x7da2641000cbb407c329310c461b2cb9c70c3046",
+        "tokenCode": "AGI"
+      },
+      {
+        "contractAddress": "0xc64500dd7b0f1794807e67802f8abbf5f8ffb054",
+        "tokenCode": "LOCUS"
+      },
+      {
+        "contractAddress": "0x6982508145454ce325ddbe47a25d4ec3d2311933",
+        "tokenCode": "PEPE"
+      },
+      {
+        "contractAddress": "0x628a3b2e302c7e896acc432d2d0dd22b6cb9bc88",
+        "tokenCode": "LMWR"
+      },
+      {
+        "contractAddress": "0x12970e6868f88f6557b76120662c1b3e50a646bf",
+        "tokenCode": "LADYS"
+      },
+      {
+        "contractAddress": "0x7448c7456a97769f6cd04f1e83a4a23ccdc46abd",
+        "tokenCode": "MAV"
+      },
+      {
+        "contractAddress": "0x808507121b80c02388fad14726482e061b8da827",
+        "tokenCode": "PENDLE"
+      },
+      {
+        "contractAddress": "0x163f8c2467924be0ae7b5347228cabf260318753",
+        "tokenCode": "WLD"
+      },
+      {
+        "contractAddress": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
+        "tokenCode": "PYUSD"
+      },
+      {
+        "contractAddress": "0x64bc2ca1be492be7185faa2c8835d9b824c8a194",
+        "tokenCode": "BIGTIME"
+      },
+      {
+        "contractAddress": "0x6e2a43be0b1d33b726f0ca3b8de60b3482b8b050",
+        "tokenCode": "ARKM"
+      },
+      {
+        "contractAddress": "0x14778860e937f509e651192a90589de711fb88a9",
+        "tokenCode": "CYBER"
+      },
+      {
+        "contractAddress": "0xb131f4a55907b10d1f0a50d8ab8fa09ec342cd74",
+        "tokenCode": "MEME"
+      },
+      {
+        "contractAddress": "0x4507cef57c46789ef8d1a19ea45f4216bae2b528",
+        "tokenCode": "TOKEN"
+      },
+      {
+        "contractAddress": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
+        "tokenCode": "POL"
+      },
+      {
+        "contractAddress": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "tokenCode": "WBTC"
+      },
+      {
+        "contractAddress": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+        "tokenCode": "ZRX"
+      },
+      {
+        "contractAddress": "0x826180541412d574cf1336d22c0c0a287822678a",
+        "tokenCode": "FLIP"
+      },
+      {
+        "contractAddress": "0x8806926ab68eb5a7b909dcaf6fdbe5d93271d6e2",
+        "tokenCode": "UQC"
+      },
+      {
+        "contractAddress": "0x6033f7f88332b8db6ad452b7c6d5bb643990ae3f",
+        "tokenCode": "LSK"
+      },
+      {
+        "contractAddress": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+        "tokenCode": "DENT"
+      },
+      {
+        "contractAddress": "0x3c3a81e81dc49a522a592e7622a7e711c06bf354",
+        "tokenCode": "MNT"
+      },
+      {
+        "contractAddress": "0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096",
+        "tokenCode": "AUCTION"
+      },
+      {
+        "contractAddress": "0xfaba6f8e4a5e8ab82f62fe7c39859fa577269be3",
+        "tokenCode": "ONDO"
+      },
+      {
+        "contractAddress": "0x8457CA5040ad67fdebbCC8EdCE889A335Bc0fbFB",
+        "tokenCode": "ALT"
+      },
+      {
+        "contractAddress": "0xf091867ec603a6628ed83d274e835539d82e9cc8",
+        "tokenCode": "ZETA"
+      },
+      {
+        "contractAddress": "0x6b0faca7ba905a86f221ceb5ca404f605e5b3131",
+        "tokenCode": "DEFI"
+      },
+      {
+        "contractAddress": "0x24fcfc492c1393274b6bcd568ac9e225bec93584",
+        "tokenCode": "MAVIA"
+      },
+      {
+        "contractAddress": "0x3429d03c6f7521aec737a0bbf2e5ddcef2c3ae31",
+        "tokenCode": "PIXEL"
+      },
+      {
+        "contractAddress": "0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766",
+        "tokenCode": "STRK"
+      },
+      {
+        "contractAddress": "0xbef26bd568e421d6708cca55ad6e35f8bfa0c406",
+        "tokenCode": "BCUT"
+      },
+      {
+        "contractAddress": "0x1bbe973bef3a977fc51cbed703e8ffdefe001fed",
+        "tokenCode": "PORTAL"
+      },
+      {
+        "contractAddress": "0x22514ffb0d7232a56f0c24090e7b68f179faa940",
+        "tokenCode": "QORPO"
+      },
+      {
+        "contractAddress": "0x0000000000085d4780b73119b644ae5ecd22b376",
+        "tokenCode": "TUSD"
+      },
+      {
+        "contractAddress": "0xb528edbef013aff855ac3c50b381f253af13b997",
+        "tokenCode": "AEVO"
+      },
+      {
+        "contractAddress": "0xfe0c30065b384f05761f15d0cc899d4f9f9cc0eb",
+        "tokenCode": "ETHFI"
+      },
+      {
+        "contractAddress": "0xc71b5f631354be6853efe9c3ab6b9590f8302e81",
+        "tokenCode": "ZKJ"
+      },
+      {
+        "contractAddress": "0x57e114b691db790c35207b2e685d4a43181e6061",
+        "tokenCode": "ENA"
+      },
+      {
+        "contractAddress": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3",
+        "tokenCode": "USDE"
+      },
+      {
+        "contractAddress": "0x243c9be13faba09f945ccc565547293337da0ad7",
+        "tokenCode": "TRUF"
+      },
+      {
+        "contractAddress": "0xacd2c239012d17beb128b0944d49015104113650",
+        "tokenCode": "KARRAT"
+      },
+      {
+        "contractAddress": "0x0921799cb1d702148131024d18fcde022129dc73",
+        "tokenCode": "LL"
+      },
+      {
+        "contractAddress": "0x5afe3855358e112b5647b952709e6165e1c1eeee",
+        "tokenCode": "SAFE"
+      },
+      {
+        "contractAddress": "0x3b50805453023a91a8bf641e279401a0b23fa6f9",
+        "tokenCode": "REZ"
+      },
+      {
+        "contractAddress": "0x10dea67478c5f8c5e2d90e5e9b26dbe60c54d800",
+        "tokenCode": "TAIKO"
+      },
+      {
+        "contractAddress": "0xbe0ed4138121ecfc5c0e56b40517da27e6c5226b",
+        "tokenCode": "ATH"
+      },
+      {
+        "contractAddress": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+        "tokenCode": "ZRO"
+      },
+      {
+        "contractAddress": "0xaaee1a9723aadb7afa2810263653a34ba2c21c7a",
+        "tokenCode": "MOG"
+      },
+      {
+        "contractAddress": "0xf944e35f95e819e752f3ccb5faf40957d311e8c5",
+        "tokenCode": "MOCA"
+      },
+      {
+        "contractAddress": "0xfeac2eae96899709a43e252b6b92971d32f9c0f9",
+        "tokenCode": "ANYONE"
+      },
+      {
+        "contractAddress": "0x38e68a37e401f7271568cecaac63c6b1e19130b4",
+        "tokenCode": "BANANA"
+      },
+      {
+        "contractAddress": "0x88909d489678dd17aa6d9609f89b0419bf78fd9a",
+        "tokenCode": "L3"
+      },
+      {
+        "contractAddress": "0x7abc8a5768e6be61a6c693a6e4eacb5b60602c4d",
+        "tokenCode": "CXT"
+      },
+      {
+        "contractAddress": "0x9c7beba8f6ef6643abd725e45a4e8387ef260649",
+        "tokenCode": "G"
+      },
+      {
+        "contractAddress": "0xabd4c63d2616a5201454168269031355f4764337",
+        "tokenCode": "ORDER"
+      },
+      {
+        "contractAddress": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
+        "tokenCode": "ROOBEE"
+      },
+      {
+        "contractAddress": "0xa35923162c49cf95e6bf26623385eb431ad920d3",
+        "tokenCode": "TURBO"
+      },
+      {
+        "contractAddress": "0x812ba41e071c7b7fa4ebcfb62df5f45f6fa853ee",
+        "tokenCode": "NEIROCTO"
+      },
+      {
+        "contractAddress": "0x56072c95faa701256059aa122697b133aded9279",
+        "tokenCode": "SKY"
+      },
+      {
+        "contractAddress": "0xec53bf9167f50cdeb3ae105f56099aaab9061f83",
+        "tokenCode": "EIGEN"
+      },
+      {
+        "contractAddress": "0xbba39fd2935d5769116ce38d46a71bde9cf03099",
+        "tokenCode": "CHO"
+      },
+      {
+        "contractAddress": "0x4d1c297d39c5c1277964d0e3f8aa901493664530",
+        "tokenCode": "PUFFER"
+      },
+      {
+        "contractAddress": "0xdbb5cf12408a3ac17d668037ce289f9ea75439d7",
+        "tokenCode": "WMTX"
+      },
+      {
+        "contractAddress": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+        "tokenCode": "COW"
+      },
+      {
+        "contractAddress": "0x0a6e7ba5042b38349e437ec6db6214aec7b35676",
+        "tokenCode": "SWELL"
+      },
+      {
+        "contractAddress": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+        "tokenCode": "CVC"
+      },
+      {
+        "contractAddress": "0xe7c6bf469e97eeb0bfb74c8dbff5bd47d4c1c98a",
+        "tokenCode": "HSK"
+      },
+      {
+        "contractAddress": "0x8ed97a637a790be1feff5e888d43629dc05408f6",
+        "tokenCode": "NPC"
+      },
+      {
+        "contractAddress": "0x58d97b57bb95320f9a05dc918aef65434969c2b2",
+        "tokenCode": "MORPHO"
+      },
+      {
+        "contractAddress": "0x643c4e15d7d62ad0abec4a9bd4b001aa3ef52d66",
+        "tokenCode": "SYRUP"
+      },
+      {
+        "contractAddress": "0xe0f63a424a4439cbe457d80e4f4b51ad25b2c56c",
+        "tokenCode": "SPX"
+      },
+      {
+        "contractAddress": "0x6e15a54b5ecac17e58dadeddbe8506a7560252f9",
+        "tokenCode": "F"
+      },
+      {
+        "contractAddress": "0x3073f7aaa4db83f95e9fff17424f71d4751a3073",
+        "tokenCode": "MOVE"
+      },
+      {
+        "contractAddress": "0xc4441c2be5d8fa8126822b9929ca0b81ea0de38e",
+        "tokenCode": "USUAL"
+      },
+      {
+        "contractAddress": "0x157a6df6b74f4e5e45af4e4615fde7b49225a662",
+        "tokenCode": "ISLAND"
+      },
+      {
+        "contractAddress": "0x675b68aa4d9c2d3bb3f0397048e62e6b7192079c",
+        "tokenCode": "FUEL"
+      },
+      {
+        "contractAddress": "0x72e4f9f808c49a2a61de9c5896298920dc4eeea9",
+        "tokenCode": "HPOS10I"
+      },
+      {
+        "contractAddress": "0x0000000000c5dc95539589fbd24be07c6c14eca4",
+        "tokenCode": "MILADYCULT"
+      },
+      {
+        "contractAddress": "0xdd3b11ef34cd511a2da159034a05fcb94d806686",
+        "tokenCode": "REKT"
+      },
+      {
+        "contractAddress": "0xcb1592591996765ec0efc1f92599a19767ee5ffa",
+        "tokenCode": "BIO"
+      },
+      {
+        "contractAddress": "0x14fee680690900ba0cccfc76ad70fd1b95d10e16",
+        "tokenCode": "PAAL"
+      },
+      {
+        "contractAddress": "0x4c1746a800d224393fe2470c70a35717ed4ea5f1",
+        "tokenCode": "PLUME"
+      },
+      {
+        "contractAddress": "0x4dc26fc5854e7648a064a4abd590bbe71724c277",
+        "tokenCode": "ANIME"
+      },
+      {
+        "contractAddress": "0x33b481cbbf3c24f2b3184ee7cb02daad1c4f49a8",
+        "tokenCode": "D"
+      },
+      {
+        "contractAddress": "0xf8f173e20e15f3b6cb686fb64724d370689de083",
+        "tokenCode": "HEI"
+      },
+      {
+        "contractAddress": "0x817162975186d4d53dbf5a7377dd45376e2d2fc5",
+        "tokenCode": "REACT"
+      },
+      {
+        "contractAddress": "0xc43c6bfeda065fe2c4c11765bf838789bd0bb5de",
+        "tokenCode": "REDSTONE"
+      },
+      {
+        "contractAddress": "0x6243558a24cc6116abe751f27e6d7ede50abfc76",
+        "tokenCode": "LVVA"
+      },
+      {
+        "contractAddress": "0x94314a14df63779c99c0764a30e0cd22fa78fc0e",
+        "tokenCode": "EPIC"
+      },
+      {
+        "contractAddress": "0x7cf9a80db3b29ee8efe3710aadb7b95270572d47",
+        "tokenCode": "NIL"
+      },
+      {
+        "contractAddress": "0x1d88713b483a8e45cff0e5cd7c2e15e5fab4534d",
+        "tokenCode": "STO"
+      },
+      {
+        "contractAddress": "0x3f80b1c54ae920be41a77f8b902259d48cf24ccf",
+        "tokenCode": "KERNEL"
+      },
+      {
+        "contractAddress": "0x28d38df637db75533bd3f71426f3410a82041544",
+        "tokenCode": "PROMPT"
+      },
+      {
+        "contractAddress": "0x868fced65edbf0056c4163515dd840e9f287a4c3",
+        "tokenCode": "SIGN"
+      },
+      {
+        "contractAddress": "0xe6bfd33f52d82ccb5b37e16d3dd81f9ffdabb195",
+        "tokenCode": "SXT"
+      },
+      {
+        "contractAddress": "0x6b7774cb12ed7573a7586e7d0e62a2a563ddd3f0",
+        "tokenCode": "SOPH"
+      },
+      {
+        "contractAddress": "0x226bb599a12c826476e3a771454697ea52e9e220",
+        "tokenCode": "PRO"
+      },
+      {
+        "contractAddress": "0x0fc2a55d5bd13033f1ee0cdd11f60f7efe66f467",
+        "tokenCode": "LA"
+      },
+      {
+        "contractAddress": "0x259338656198ec7a76c729514d3cb45dfbf768a1",
+        "tokenCode": "RESOLV"
+      },
+      {
+        "contractAddress": "0x7ddc52c4de30e94be3a6a0a2b259b2850f421989",
+        "tokenCode": "GOMINING"
+      },
+      {
+        "contractAddress": "0xc20059e0317de91738d13af027dfc4a50781b066",
+        "tokenCode": "SPK"
+      },
+      {
+        "contractAddress": "0xe76c5b78f93909d34404e9eb4c1f19e7582a5de1",
+        "tokenCode": "H"
+      },
+      {
+        "contractAddress": "0xd0ec028a3d21533fdd200838f39c85b03679285d",
+        "tokenCode": "NEWT"
+      },
+      {
+        "contractAddress": "0xfdffb411c4a70aa7c95d5c981a6fb4da867e1111",
+        "tokenCode": "SAHARA"
+      },
+      {
+        "contractAddress": "0x68749665ff8d2d112fa859aa293f07a622782f38",
+        "tokenCode": "XAUT"
+      },
+      {
+        "contractAddress": "0x2f714d7b9a035d4ce24af8d9b6091c07e37f43fb",
+        "tokenCode": "NODE"
+      },
+      {
+        "contractAddress": "0x699ccf919c1dfdfa4c374292f42cadc9899bf753",
+        "tokenCode": "VSN"
+      },
+      {
+        "contractAddress": "0xe2ad0bf751834f2fbdc62a41014f84d67ca1de2a",
+        "tokenCode": "ERA"
+      },
+      {
+        "contractAddress": "0x95af4af910c28e8ece4512bfe46f1f33687424ce",
+        "tokenCode": "MANYU"
+      },
+      {
+        "contractAddress": "0xbbcdc8eb044bf661eabfa07b93909a76ebdb1100",
+        "tokenCode": "ELP"
+      },
+      {
+        "contractAddress": "0x77146784315ba81904d654466968e3a7c196d1f3",
+        "tokenCode": "TREE"
+      },
+      {
+        "contractAddress": "0x2ee7097bfdd98fce2ac08a1896038a7cd9aaed81",
+        "tokenCode": "GAIA"
+      },
+      {
+        "contractAddress": "0x000000fa00b200406de700041cfc6b19bbfb4d13",
+        "tokenCode": "TOWNS"
+      },
+      {
+        "contractAddress": "0x6bef15d938d4e72056ac92ea4bdd0d76b1c4ad29",
+        "tokenCode": "PROVE"
+      },
+      {
+        "contractAddress": "0x61fac5f038515572d6f42d4bcb6b581642753d50",
+        "tokenCode": "IN"
+      },
+      {
+        "contractAddress": "0xf94e7d0710709388bce3161c32b4eea56d3f91cc",
+        "tokenCode": "DSYNC"
+      },
+      {
+        "contractAddress": "0x84eaac1b2dc3f84d92ff84c3ec205b1fa74671fc",
+        "tokenCode": "CAMP"
+      },
+      {
+        "contractAddress": "0xda5e1988097297dcdc1f90d4dfe7909e847cbef6",
+        "tokenCode": "WLFI"
+      },
+      {
+        "contractAddress": "0xba5ed44733953d79717f6269357c77718c8ba5ed",
+        "tokenCode": "UNION"
+      },
+      {
+        "contractAddress": "0xfca59cd816ab1ead66534d82bc21e7515ce441cf",
+        "tokenCode": "RARI"
+      },
+      {
+        "contractAddress": "0xa227cc36938f0c9e09ce0e64dfab226cad739447",
+        "tokenCode": "OPEN"
+      },
+      {
+        "contractAddress": "0x6944e1df6bf5972305f9ab25df47ef10de01bcc8",
+        "tokenCode": "UB"
+      },
+      {
+        "contractAddress": "0x000006c2a22ff4a44ff1f5d0f2ed65f781f55555",
+        "tokenCode": "ZKC"
+      },
+      {
+        "contractAddress": "0xf72ae3e0da743033abd7a407557d684c1ae66aed",
+        "tokenCode": "XL1"
+      },
+      {
+        "contractAddress": "0xf0db65d17e30a966c2ae6a21f6bba71cea6e9754",
+        "tokenCode": "BARD"
+      },
+      {
+        "contractAddress": "0xcedbea37c8872c4171259cdfd5255cb8923cf8e7",
+        "tokenCode": "XAN"
+      },
+      {
+        "contractAddress": "0x2e44f3f609ff5aa4819b323fd74690f07c3607c4",
+        "tokenCode": "PIN"
+      },
+      {
+        "contractAddress": "0xfa1c09fc8b491b6a4d3ff53a10cad29381b3f949",
+        "tokenCode": "FF"
+      },
+      {
+        "contractAddress": "0x24a3d725c37a8d1a66eb87f0e5d07fe67c120035",
+        "tokenCode": "EDEN"
+      },
+      {
+        "contractAddress": "0x699f088b5dddcafb7c4824db5b10b57b37cb0c66",
+        "tokenCode": "ENSO"
+      },
+      {
+        "contractAddress": "0x6e6f6d696e61decd6605bd4a57836c5db6923340",
+        "tokenCode": "NOM"
+      },
+      {
+        "contractAddress": "0x01791f726b4103694969820be083196cc7c045ff",
+        "tokenCode": "YB"
+      },
+      {
+        "contractAddress": "0x66fd8de541c0594b4dccdfc13bf3a390e50d3afd",
+        "tokenCode": "TURTLE"
+      },
+      {
+        "contractAddress": "0x13239c268beddd88ad0cb02050d3ff6a9d00de6d",
+        "tokenCode": "BOS"
+      },
+      {
+        "contractAddress": "0x50f41f589afaca2ef41fdf590fe7b90cd26dee64",
+        "tokenCode": "IRYS"
+      },
+      {
+        "contractAddress": "0x8b1484d57abbe239bb280661377363b03c89caea",
+        "tokenCode": "ADI"
+      },
+      {
+        "contractAddress": "0xb8f28c60dd8240141185a192fa4156a23e189305",
+        "tokenCode": "KYO"
+      },
+      {
+        "contractAddress": "0x712bd4beb54c6b958267d9db0259abdbb0bff606",
+        "tokenCode": "UDS"
+      },
+      {
+        "contractAddress": "0xb31561f0e2aac72406103b1926356d756f07a481",
+        "tokenCode": "VOOI"
+      },
+      {
+        "contractAddress": "0xe1be424f442d0687129128c6c38aace44f8c8dbc",
+        "tokenCode": "ZKP"
+      },
+      {
+        "contractAddress": "0xb2617246d0c6c0087f18703d576831899ca94f01",
+        "tokenCode": "ZIG"
+      },
+      {
+        "contractAddress": "0x232ce3bd40fcd6f80f3d55a522d03f25df784ee2",
+        "tokenCode": "LIT"
+      },
+      {
+        "contractAddress": "0x086f405146ce90135750bbec9a063a8b20a8bffb",
+        "tokenCode": "BREV"
+      },
+      {
+        "contractAddress": "0xa6773c4f26c80c86bc04aa6506533693a39d1195",
+        "tokenCode": "ZTC"
+      },
+      {
+        "contractAddress": "0x216b3643ff8b7bb30d8a48e9f1bd550126202add",
+        "tokenCode": "ACU"
+      },
+      {
+        "contractAddress": "0x2798b1cc5a993085e8a9d46e80499f1b63f42204",
+        "tokenCode": "GWEI"
+      },
+      {
+        "contractAddress": "0x56a3ba04e95d34268a19b2a4474dc979babdaf76",
+        "tokenCode": "SENT"
+      },
+      {
+        "contractAddress": "0xb48c6b24f36307c7a1f2a9281e978a9ef2902ba5",
+        "tokenCode": "IMU"
+      },
+      {
+        "contractAddress": "0x87acfa3fd7a6e0d48677d070644d76905c2bdc00",
+        "tokenCode": "SPACE"
+      },
+      {
+        "contractAddress": "0xa12cc123ba206d4031d1c7f6223d1c2ec249f4f3",
+        "tokenCode": "ZAMA"
+      },
+      {
+        "contractAddress": "0xdef1b2d939edc0e4d35806c59b3166f790175afe",
+        "tokenCode": "INX"
+      },
+      {
+        "contractAddress": "0x228bec415ade4b61d7caf0adf8c91eac587ba369",
+        "tokenCode": "TRIA"
+      },
+      {
+        "contractAddress": "0x031de51f3e8016514bd0963d0b2ab825a591db9a",
+        "tokenCode": "ESP"
+      },
+      {
+        "contractAddress": "0xa27ec0006e59f245217ff08cd52a7e8b169e62d2",
+        "tokenCode": "AZTEC"
+      },
+      {
+        "contractAddress": "0x32b4d049fe4c888d2b92eecaf729f44df6b1f36e",
+        "tokenCode": "ROBO"
+      },
+      {
+        "contractAddress": "0xd3f58365428f9325d13787a405f846374a58a0fb",
+        "tokenCode": "NOON"
+      },
+      {
+        "contractAddress": "0xe3872dd4eba50598c54b2aa21b04c71fc37b000b",
+        "tokenCode": "NEXI"
+      },
+      {
+        "contractAddress": "0x2103e845c5e135493bb6c2a4f0b8651956ea8682",
+        "tokenCode": "XAUM"
+      },
+      {
+        "contractAddress": "0x4f2b33840227ddd0e28da8d4185d6fa07adfed87",
+        "tokenCode": "BASED"
+      },
+      {
+        "contractAddress": "0xb0076de78dc50581770bba1d211ddc0ad4f2a241",
+        "tokenCode": "EDGE"
+      },
+      {
+        "contractAddress": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+        "tokenCode": "USDS"
+      },
+      {
+        "contractAddress": "0x9cb7a4ef0cae65b07362bc679a0b874041e3da53",
+        "tokenCode": "OFC"
+      },
+      {
+        "contractAddress": "0x17205fab260a7a6383a81452ce6315a39370db97",
+        "tokenCode": "RAVE"
+      },
+      {
+        "contractAddress": "0xd8a271974e8edae9d7b58e3370dc1669427503f4",
+        "tokenCode": "BLEND"
+      },
+      {
+        "contractAddress": "0x3e76dd57e649a263a532cc9bcc58b32a065fb2a4",
+        "tokenCode": "ACN"
+      },
+      {
+        "contractAddress": "0x4d7078ddd6ccfed2f85db5b7d3ff16828d378d48",
+        "tokenCode": "AI"
+      },
+      {
+        "contractAddress": "0x99e980265bf36516c442be982df1772a6ccb3233",
+        "tokenCode": "ASSET"
+      },
+      {
+        "contractAddress": "0xb1110919016846972056ab995054d65560d5f05e",
+        "tokenCode": "BILL"
+      },
+      {
+        "contractAddress": "0x00bac91fd8f5b4a0dc03c8021139b76f6549ee7e",
+        "tokenCode": "KAIO"
+      },
+      {
+        "contractAddress": "0x7def4573628021500c3207994935a51801fb56be",
+        "tokenCode": "AKITA"
+      },
+      {
+        "contractAddress": "0xf57d49646621f563b0b905afc8336923ac569ec5",
+        "tokenCode": "NEX"
+      },
+      {
+        "contractAddress": "0x0e63b9c287e32a05e6b9ab8ee8df88a2760225a9",
+        "tokenCode": "PIEVERSE"
+      },
+      {
+        "contractAddress": "0x7ea7ea50ed58bc4d0a9194bcd328e21f7be80c2b",
+        "tokenCode": "TEA"
+      },
+      {
+        "contractAddress": "0x526526528f35ac738177003b8773b402b8df8143",
+        "tokenCode": "RE"
+      },
+      {
+        "contractAddress": "0x230f1e241c621d5af670dad83ebcdd18971e2995",
+        "tokenCode": "NES"
+      },
+      {
+        "contractAddress": "0x99991c6aabba5a096f24f250b73580f5179b9999",
+        "tokenCode": "CAP"
+      },
+      {
+        "contractAddress": "0xb30fe1cf884b48a22a50d22a9282004f2c5e9406",
+        "tokenCode": "GROVE"
+      },
+      {
+        "contractAddress": "0xAD29F2723fcdBcF665F210F25E06f97477e417cF",
+        "tokenCode": "GRVT"
+      },
+      {
+        "contractAddress": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+        "tokenCode": "STETH"
+      },
+      {
+        "contractAddress": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
+        "tokenCode": "GALA"
+      },
+      {
+        "contractAddress": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+        "tokenCode": "NEXO"
+      },
+      {
+        "contractAddress": "0x11eef04c884e24d9b7b4760e7476d06ddf797f36",
+        "tokenCode": "MX"
+      },
+      {
+        "contractAddress": "0x52a8845df664d76c69d2eea607cd793565af42b8",
+        "tokenCode": "APEX"
+      },
+      {
+        "contractAddress": "0xb23d80f5FefcDDaa212212F028021B41DEd428CF",
+        "tokenCode": "PRIME"
+      },
+      {
+        "contractAddress": "0x467719aD09025FcC6cF6F8311755809d45a5E5f3",
+        "tokenCode": "AXL"
+      },
+      {
+        "contractAddress": "0x62D0A8458eD7719FDAF978fe5929C6D342B0bFcE",
+        "tokenCode": "BEAM"
+      },
+      {
+        "contractAddress": "0x0649Cef6D11ed6F88535462E147304d3FE5ae14D",
+        "tokenCode": "KUB"
+      },
+      {
+        "contractAddress": "0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa",
+        "tokenCode": "METH"
+      },
+      {
+        "contractAddress": "0x96F6eF951840721AdBF46Ac996b59E0235CB985C",
+        "tokenCode": "USDY"
+      },
+      {
+        "contractAddress": "0xdBB7a34Bf10169d6d2D0d02A6cbb436cF4381BFa",
+        "tokenCode": "ZENT"
+      },
+      {
+        "contractAddress": "0x7613C48E0cd50E42dD9Bf0f6c235063145f6f8DC",
+        "tokenCode": "PIRATE"
+      },
+      {
+        "contractAddress": "0x3E5A19c91266aD8cE2477B91585d1856B84062dF",
+        "tokenCode": "A8"
+      },
+      {
+        "contractAddress": "0x9F0C013016E8656bC256f948CD4B79ab25c7b94D",
+        "tokenCode": "COOK"
+      },
+      {
+        "contractAddress": "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb",
+        "tokenCode": "FLUID"
+      },
+      {
+        "contractAddress": "0x76A0e27618462bDAC7a29104bdcfFf4E6BFCea2D",
+        "tokenCode": "SOSO"
+      },
+      {
+        "contractAddress": "0x5c8D0C48810FD37A0A824D074ee290E64f7A8Fa2",
+        "tokenCode": "AVL"
+      },
+      {
+        "contractAddress": "0xC139190F447e929f090Edeb554D95AbB8b18aC1C",
+        "tokenCode": "USDTB"
+      },
+      {
+        "contractAddress": "0xc43C6bfeDA065fE2c4c11765Bf838789bd0BB5dE",
+        "tokenCode": "RED"
+      },
+      {
+        "contractAddress": "0x44f49ff0da2498bCb1D3Dc7C0f999578F67FD8C6",
+        "tokenCode": "CORN"
+      },
+      {
+        "contractAddress": "0xC08e7E23C235073C6807C2EFE7021304cb7c2815",
+        "tokenCode": "XUSD"
+      },
+      {
+        "contractAddress": "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+        "tokenCode": "RLUSD"
+      },
+      {
+        "contractAddress": "0xC19D38925F9F645337B1D1f37bAf3C0647A48E50",
+        "tokenCode": "GAIB"
+      },
+      {
+        "contractAddress": "0x07041776f5007ACa2A54844F50503a18A72A8b68",
+        "tokenCode": "USAT"
+      },
+      {
+        "contractAddress": "0xFC347c996BD66C1d92E2045c80b413ef3fc84A90",
+        "tokenCode": "AEDZ"
+      },
+      {
+        "contractAddress": "0xDB6Ba5D510F114F9b2eA08BEa7d30e32eEe33411",
+        "tokenCode": "BSB"
+      }
+    ]
+  ],
+  [
+    "ETHEREUM POW",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ETHW"
+      }
+    ]
+  ],
+  [
+    "FIL",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "FIL"
+      }
+    ]
+  ],
+  [
+    "HBAR",
+    [
+      {
+        "contractAddress": "0.0.456858",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "HBAR"
+      }
+    ]
+  ],
+  [
+    "HYPEREVM",
+    [
+      {
+        "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "HYPE:0x0d01dc56dcaaca66ad901c959b4011ec",
+        "tokenCode": "HYPE"
+      }
+    ]
+  ],
+  [
+    "LTC",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "LTC"
+      }
+    ]
+  ],
+  [
+    "MONAD",
+    [
+      {
+        "contractAddress": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "0x754704bc059f8c67012fed69bc8a327a5aafb603",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": "0x01bFF41798a0BcF287b996046Ca68b395DbC1071",
+        "tokenCode": "XAUT"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "MON"
+      }
+    ]
+  ],
+  [
+    "OP",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ETH"
+      },
+      {
+        "contractAddress": "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": "0x4200000000000000000000000000000000000042",
+        "tokenCode": "OP"
+      },
+      {
+        "contractAddress": "0xdc6ff44d5d932cbd77b52e5612ba0529dc6226f1",
+        "tokenCode": "WLD"
+      },
+      {
+        "contractAddress": "0x14778860e937f509e651192a90589de711fb88a9",
+        "tokenCode": "CYBER"
+      },
+      {
+        "contractAddress": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
+        "tokenCode": "ZRO"
+      },
+      {
+        "contractAddress": "0xef4461891dfb3ac8572ccf7c794664a8dd927945",
+        "tokenCode": "WCT"
+      }
+    ]
+  ],
+  [
+    "OSMO",
+    [
+      {
+        "contractAddress": "uosmo",
+        "tokenCode": "OSMO"
+      }
+    ]
+  ],
+  [
+    "POL",
+    [
+      {
+        "contractAddress": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "tokenCode": "TEL"
+      },
+      {
+        "contractAddress": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": "0x311434160d7537be358930def317afb606c0d737",
+        "tokenCode": "NAKA"
+      },
+      {
+        "contractAddress": "0x692ac1e363ae34b6b489148152b12e2785a3d8d6",
+        "tokenCode": "TRADE"
+      },
+      {
+        "contractAddress": "0x714DB550b574b3E927af3D93E26127D15721D4C2",
+        "tokenCode": "GMT"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "POL"
+      },
+      {
+        "contractAddress": "0xf0949dd87d2531d665010d6274f06a357669457a",
+        "tokenCode": "RMV"
+      },
+      {
+        "contractAddress": "0x98965474ecbec2f532f1f780ee37b0b05f77ca55",
+        "tokenCode": "SUT"
+      },
+      {
+        "contractAddress": "0xEB7eaB87837f4Dad1bb80856db9E4506Fc441f3D",
+        "tokenCode": "MEE"
+      }
+    ]
+  ],
+  [
+    "QTUM",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "QTUM"
+      }
+    ]
+  ],
+  [
+    "RUNE",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "RUNE"
+      }
+    ]
+  ],
+  [
+    "SOL",
+    [
+      {
+        "contractAddress": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "SOL"
+      },
+      {
+        "contractAddress": "hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux",
+        "tokenCode": "HNT"
+      },
+      {
+        "contractAddress": "EchesyfXePKdLtoiZSL8pBe8Myagyy8ZRqsACNCFGnvp",
+        "tokenCode": "FIDA"
+      },
+      {
+        "contractAddress": "5MAYDfq5yxtudAhtfyuMBuHZjgAbaS9tbEyEQYAhDS5y",
+        "tokenCode": "ACS"
+      },
+      {
+        "contractAddress": "octo82drBEdm8CSDaEKBymVn86TBtgmPnDdmE64PTqJ",
+        "tokenCode": "OTK"
+      },
+      {
+        "contractAddress": "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3",
+        "tokenCode": "PYTH"
+      },
+      {
+        "contractAddress": "5XZw2LKTyrfvfiskJ78AMpackRjPcyCif1WhUsPDuVqQ",
+        "tokenCode": "WBTC"
+      },
+      {
+        "contractAddress": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+        "tokenCode": "BONK"
+      },
+      {
+        "contractAddress": "4SoQ8UkWfeDH47T56PA53CZCeW4KytYCiU65CwBWoJUt",
+        "tokenCode": "MNT"
+      },
+      {
+        "contractAddress": "jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",
+        "tokenCode": "JTO"
+      },
+      {
+        "contractAddress": "Bm3dgkZrjH7eaz1GBH1R2ZHkp7nZUoPNJhjekoxepump",
+        "tokenCode": "MYRO"
+      },
+      {
+        "contractAddress": "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
+        "tokenCode": "RAY"
+      },
+      {
+        "contractAddress": "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE",
+        "tokenCode": "ORCA"
+      },
+      {
+        "contractAddress": "NeonTjSjsuo3rexg9o6vHuMXw62f9V7zvmu8M8Zut44",
+        "tokenCode": "NEON"
+      },
+      {
+        "contractAddress": "EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm",
+        "tokenCode": "WIF"
+      },
+      {
+        "contractAddress": "SarosY6Vscao718M4A778z4CGtvcwcGef5M9MEH1LGL",
+        "tokenCode": "SAROS"
+      },
+      {
+        "contractAddress": "WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk",
+        "tokenCode": "WEN"
+      },
+      {
+        "contractAddress": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+        "tokenCode": "JUP"
+      },
+      {
+        "contractAddress": "ukHH6c7mMyiWCf1b9pnWe25TSpkDDt3H5pQZgZ74J82",
+        "tokenCode": "BOME"
+      },
+      {
+        "contractAddress": "85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ",
+        "tokenCode": "W"
+      },
+      {
+        "contractAddress": "MEW1gQWJ3nEXg2qgERiKu7FAFj79PHvQVREQUzScPP5",
+        "tokenCode": "MEW"
+      },
+      {
+        "contractAddress": "ZEUS1aR7aX8DFFJf5QjWj2ftDDdNTroMNGo8YoQm3Gq",
+        "tokenCode": "ZEUS"
+      },
+      {
+        "contractAddress": "TNSRxcUxoT9xBG3de7PiJyTDYu7kskLqcpddxnEJAS6",
+        "tokenCode": "TNSR"
+      },
+      {
+        "contractAddress": "4LLbsb5ReP3yEtYzmXewyGjcir5uXtKFURtaEUVC2AHs",
+        "tokenCode": "PRCL"
+      },
+      {
+        "contractAddress": "KMNo3nJsBXfcpJTVhZcXLW7RmTwTt4GVFE7suUBo9sS",
+        "tokenCode": "KMNO"
+      },
+      {
+        "contractAddress": "ZBCNpuD7YMXzTHB2fhGkGi78MNsHGLRXUhRewNRm9RU",
+        "tokenCode": "ZBCN"
+      },
+      {
+        "contractAddress": "DriFtupJYLTosbwoN8koMbEYSx54aFAVLddWsbksjwg7",
+        "tokenCode": "DRIFT"
+      },
+      {
+        "contractAddress": "BZLbGTNCSFfoth2GYDtwr7e4imWzpR5jqcUuGEwr646K",
+        "tokenCode": "IO"
+      },
+      {
+        "contractAddress": "FRySi8LPkuByB7VPSCCggxpewFUeeJiwEGRKKuhwpKcX",
+        "tokenCode": "NATIX"
+      },
+      {
+        "contractAddress": "rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof",
+        "tokenCode": "RENDER"
+      },
+      {
+        "contractAddress": "7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr",
+        "tokenCode": "POPCAT"
+      },
+      {
+        "contractAddress": "ED5nyyWEzpPPiWimP8vYm7sD7TD3LAt3Q3gRTWHzPJBY",
+        "tokenCode": "MOODENG"
+      },
+      {
+        "contractAddress": "5z3EqYQo9HiCEs3R84RCDMu2n7anpDMxRhdK8PSWmrRC",
+        "tokenCode": "PONKE"
+      },
+      {
+        "contractAddress": "DBRiDgJAMsM95moTzJs7M9LnkGErpbv9v6CUR1DXnUu5",
+        "tokenCode": "DBR"
+      },
+      {
+        "contractAddress": "CzLSujWBLFsSjncfkh59rUFqvafWcY5tzedWJSuypump",
+        "tokenCode": "GOAT"
+      },
+      {
+        "contractAddress": "Grass7B4RdKfBCjTKgSqnXkqjwiGvQyFbuSCUJr3XXjs",
+        "tokenCode": "GRASS"
+      },
+      {
+        "contractAddress": "GJAFwWjJ3vnTsrQVabjBVK2TYB1YtRCQXRDfDgUnpump",
+        "tokenCode": "ACT"
+      },
+      {
+        "contractAddress": "2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump",
+        "tokenCode": "PNUT"
+      },
+      {
+        "contractAddress": "9PR7nCP9DpcUotnDPVLUBUZKu5WAYkwrCUx9wDnSpump",
+        "tokenCode": "BAN"
+      },
+      {
+        "contractAddress": "HKJHsYJHMVK5VRyHHk5GhvzY9tBAAtPvDkZfDH6RLDTd",
+        "tokenCode": "READY"
+      },
+      {
+        "contractAddress": "Df6yfrKC8kZE3KNkrHERKzAetSxbrWeniQfyJY4Jpump",
+        "tokenCode": "CHILLGUY"
+      },
+      {
+        "contractAddress": "DKu9kykSfbN5LBfFXtNNDPaX35o4Fv6vJ9FKk7pZpump",
+        "tokenCode": "AVAAI"
+      },
+      {
+        "contractAddress": "63LfDmNb3MQ8mw9MtZ2To9bEA2M71kZUUGq5tiJxcqj9",
+        "tokenCode": "GIGA"
+      },
+      {
+        "contractAddress": "8x5VqbHA8D7NkD52uNuS5nnt3PwA8pLD34ymskeSo2Wn",
+        "tokenCode": "ZEREBRO"
+      },
+      {
+        "contractAddress": "MEFNBXixkEbait3xn9bkm8WsJzXtVsaJEn4c8Sam21u",
+        "tokenCode": "ME"
+      },
+      {
+        "contractAddress": "STREAMribRwybYpMmSYoCsQUdr6MZNXEqHgm7p1gu9M",
+        "tokenCode": "STREAM"
+      },
+      {
+        "contractAddress": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+        "tokenCode": "PENGU"
+      },
+      {
+        "contractAddress": "9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump",
+        "tokenCode": "FARTCOIN"
+      },
+      {
+        "contractAddress": "KENJSUYLASHUMfHyy5o4Hp2FdNqZg1AsUPhfH2kYvEP",
+        "tokenCode": "GRIFFAIN"
+      },
+      {
+        "contractAddress": "61V8vBaqAGMpgDQi4JcAwo1dmBGHsyhzodcPqnEVpump",
+        "tokenCode": "ARC"
+      },
+      {
+        "contractAddress": "74SBV4zDXxTRgv1pEMoECskKBkZHc2yGPnc7GYVepump",
+        "tokenCode": "SWARMS"
+      },
+      {
+        "contractAddress": "CLoUDKc4Ane7HeQcPpE3YHnznRxhMimJ4MyaUqyHFzAu",
+        "tokenCode": "CLOUD"
+      },
+      {
+        "contractAddress": "B89Hd5Juz7JP2dxCZXFJWk4tMTcbw7feDhuWGb3kq5qE",
+        "tokenCode": "NC"
+      },
+      {
+        "contractAddress": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
+        "tokenCode": "TRUMP"
+      },
+      {
+        "contractAddress": "FUAfBo2jgks6gB4Z4LfZkqSZgzNucisEHqnNebaRxM1P",
+        "tokenCode": "MELANIA"
+      },
+      {
+        "contractAddress": "6AJcP7wuLwmRYLBNbi825wgguaPsWzPBEHcHndpRpump",
+        "tokenCode": "VINE"
+      },
+      {
+        "contractAddress": "FeR8VBqNRSUD5NtXAj2n3j1dAHkZHfyDktKuLXD4pump",
+        "tokenCode": "JELLYJELLY"
+      },
+      {
+        "contractAddress": "LAYER4xPpTCb3QL8S9u41EAhAX7mhBn8Q6xMTwY2Yzc",
+        "tokenCode": "LAYER"
+      },
+      {
+        "contractAddress": "A8C3xuqscfmyLrte3VmTqrAq8kgMASius9AFNANwpump",
+        "tokenCode": "FWOG"
+      },
+      {
+        "contractAddress": "RoamA1USA8xjvpTJZ6RvvxyDRzNh6GCA1zVGKSiMVkn",
+        "tokenCode": "ROAM"
+      },
+      {
+        "contractAddress": "4vMsoUT2BWatFweudnQM1xedRLfJgJ7hswhcpz4xgBTy",
+        "tokenCode": "HONEY"
+      },
+      {
+        "contractAddress": "FQgtfugBdpFN7PZ6NdPrZpVLDBrPGxXesi4gVu3vErhY",
+        "tokenCode": "BMT"
+      },
+      {
+        "contractAddress": "Hax9LTgsQkze1YFychnBLtFH8gYbQKtKfWKKg2SP6gdD",
+        "tokenCode": "TAI"
+      },
+      {
+        "contractAddress": "5UUH9RTDiSpq6HKS6bp4NdU9PNJpXRXuiw6ShBTBhgH2",
+        "tokenCode": "TROLL"
+      },
+      {
+        "contractAddress": "DvjbEsdca43oQcw2h3HW1CT7N3x5vRcr3QrvTUHnXvgV",
+        "tokenCode": "DOOD"
+      },
+      {
+        "contractAddress": "Dz9mQ9NzkBcCsuGPFJ3r1bS4wgqKMHBPiVuniW8Mbonk",
+        "tokenCode": "USELESS"
+      },
+      {
+        "contractAddress": "USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB",
+        "tokenCode": "USD1"
+      },
+      {
+        "contractAddress": "4eDf52YYzL6i6gbZ6FXqrLUPXbtP61f1gPSFM66M4XHe",
+        "tokenCode": "SOON"
+      },
+      {
+        "contractAddress": "HUMA1821qVDKta3u2ovmfDQeW2fSQouSKE8fkF44wvGw",
+        "tokenCode": "HUMA"
+      },
+      {
+        "contractAddress": "AymATz4TCL9sWNEEV9Kvyz45CHVhDZ6kUgjTJPzLpU9P",
+        "tokenCode": "XAUT"
+      },
+      {
+        "contractAddress": "8ZHE4ow1a2jjxuoMfyExuNamQNALv5ekZhsBn5nMDf5e",
+        "tokenCode": "MORI"
+      },
+      {
+        "contractAddress": "pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn",
+        "tokenCode": "PUMP"
+      },
+      {
+        "contractAddress": "CN162nCPpq3DxPCyKLbAvEJeB1aCxsnVTEG4ZU8vpump",
+        "tokenCode": "A47"
+      },
+      {
+        "contractAddress": "C29ebrgYjYoJPMGPnPSGY1q3mMGk4iDSqnQeQQA7moon",
+        "tokenCode": "NOBODY"
+      },
+      {
+        "contractAddress": "HgBRWfYxEfvPhtqkaeymCQtHCrKE46qQ43pKe8HCpump",
+        "tokenCode": "BERT"
+      },
+      {
+        "contractAddress": "XLnpFRQ3rSWupCRjuQfx74mgVoT3ezVJKE1CogRZxhH",
+        "tokenCode": "XLAB"
+      },
+      {
+        "contractAddress": "WLFinEv6ypjkczcS83FZqFpgFZYwQXutRbxGe7oC16g",
+        "tokenCode": "WLFI"
+      },
+      {
+        "contractAddress": "69RX85eQoEsnZvXGmLNjYcWgVkp9r2JjahVm99KbJETU",
+        "tokenCode": "HOLO"
+      },
+      {
+        "contractAddress": "PRTLSwfLzpVGSAQiUfXEenJkq1cwTsEcsn1hPL9zwwg",
+        "tokenCode": "PORTALS"
+      },
+      {
+        "contractAddress": "J6pQQ3FAcJQeWPPGppWRb4nM8jU3wLyYbRrLh7feMfvd",
+        "tokenCode": "2Z"
+      },
+      {
+        "contractAddress": "moonThZEkkTVoNB7v6YVCQiT56JYDZ1oN185ba3WizL",
+        "tokenCode": "MF"
+      },
+      {
+        "contractAddress": "7s9MoSt7VV1J3jVNnw2AyocsQDBdCkPYz5apQDPKy9i5",
+        "tokenCode": "PIPE"
+      },
+      {
+        "contractAddress": "METvsvVRapdj9cFLzq4Tr43xK4tAjQfwX76z3n6mWQL",
+        "tokenCode": "MET"
+      },
+      {
+        "contractAddress": "375aiUqZERLrB9sHtsArKr4nuWCgBrtqibUDBMGeLvZC",
+        "tokenCode": "EAT"
+      },
+      {
+        "contractAddress": "DuMbhu7mvQvqQHGcnikDgb4XegXJRyhUBfdU22uELiZA",
+        "tokenCode": "ELIZAOS"
+      },
+      {
+        "contractAddress": "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH",
+        "tokenCode": "USDG"
+      },
+      {
+        "contractAddress": "WETZjtprkDMCcUxPi9PfWnowMRZkiGGHDb9rABuRZ2U",
+        "tokenCode": "WET"
+      },
+      {
+        "contractAddress": "SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3",
+        "tokenCode": "SKR"
+      },
+      {
+        "contractAddress": "8f62NyJGo7He5uWeveTA2JJQf4xzf8aqxkmzxRQ3mxfU",
+        "tokenCode": "FIGHT"
+      },
+      {
+        "contractAddress": "D6xWgRCSHoMEB5fqPwk3p6Stxirn5ytm2WwboSTTx4oE",
+        "tokenCode": "PYBOBO"
+      },
+      {
+        "contractAddress": "G7vQWurMkMMm2dU3iZpXYFTHT9Biio4F4gZCrwFpKNwG",
+        "tokenCode": "BIRB"
+      },
+      {
+        "contractAddress": "8UKuetxWnpC9Po9Mpf3ptT2wEvkqg9GxZWnnx4VPhpeD",
+        "tokenCode": "PVT"
+      },
+      {
+        "contractAddress": "HmMubgKx91Tpq3jmfcKQwsv5HrErqnCTTRJMB6afFR2u",
+        "tokenCode": "9BIT"
+      },
+      {
+        "contractAddress": "PERLEQKUNUp1dgFZ8EvyXHdN9d6ZQqfGxALDvfs6pDs",
+        "tokenCode": "PRL"
+      },
+      {
+        "contractAddress": "BWsnyEa1XtsNRdgPaDoA1WVUonF7BBGZTd2zc72NQsWT",
+        "tokenCode": "BLEND"
+      },
+      {
+        "contractAddress": "METAwkXcqyXKy1AtsSgJ8JiUHwGCafnZL38n3vYmeta",
+        "tokenCode": "METADAO"
+      },
+      {
+        "contractAddress": "STARqri3xhy6Pyv1EpgdjkPDVcs9FncKcaEP6527krs",
+        "tokenCode": "STAR"
+      },
+      {
+        "contractAddress": "ARXwZkNAtzPfdcoqQiduJn8EPv9fKiDfGn2KyggyDrFs",
+        "tokenCode": "ARX"
+      },
+      {
+        "contractAddress": "CWZ6BsdnjkDVTGkmL6bGbJXXig6ceef12KvyGQW14cMt",
+        "tokenCode": "ANTFUN"
+      },
+      {
+        "contractAddress": "CARDSccUMFKoPRZxt5vt3ksUbxEFEcnZ3H2pd3dKxYjp",
+        "tokenCode": "CARDS"
+      },
+      {
+        "contractAddress": "9cRCn9rGT8V2imeM2BaKs13yhMEais3ruM3rPvTGpump",
+        "tokenCode": "ANSEM"
+      },
+      {
+        "contractAddress": "METAewgxyPbgwsseH8T16a39CQ5VyVxZi9zXiDPY18m",
+        "tokenCode": "MPLX"
+      },
+      {
+        "contractAddress": "Bybit2vBJGhPF52GBdNaQfUJ6ZpThSgHBobjWZpLPb4B",
+        "tokenCode": "BBSOL"
+      },
+      {
+        "contractAddress": "HNg5PYJmtqcmzXrv6S9zP1CDKk5BgDuyFBxbvNApump",
+        "tokenCode": "ALCH"
+      },
+      {
+        "contractAddress": "SonicxvLud67EceaEzCLRnMTBqzYUUYNr93DBkBdDES",
+        "tokenCode": "SONIC"
+      },
+      {
+        "contractAddress": "CudisfkgWvMKnZ3TWf6iCuHm8pN2ikXhDcWytwz6f6RN",
+        "tokenCode": "CUDIS"
+      },
+      {
+        "contractAddress": "Xsc9qvGR1efVDFGLrVsmkzv3qi45LTBjeUKSPmx9qEh",
+        "tokenCode": "NVDAX"
+      },
+      {
+        "contractAddress": "Xs7ZdzSHLU9ftNJsii5fCeJhoRWSC32SQGzGQtePxNu",
+        "tokenCode": "COINX"
+      },
+      {
+        "contractAddress": "XsbEhLAtcf6HdfpFZ5xEMdqW8nfAvcsP5bdudRLJzJp",
+        "tokenCode": "AAPLX"
+      },
+      {
+        "contractAddress": "XsueG8BtpquVJX9LVLLEGuViXUungE6WmK5YZ3p3bd1",
+        "tokenCode": "CRCLX"
+      },
+      {
+        "contractAddress": "Xsa62P5mvPszXL1krVUnU5ar38bBSVcWAB6fmPCo5Zu",
+        "tokenCode": "METAX"
+      },
+      {
+        "contractAddress": "XsvNBAYkrDRNhA7wPHQfX3ZUXZyZLdnCQDfHZ56bzpg",
+        "tokenCode": "HOODX"
+      },
+      {
+        "contractAddress": "Xs3eBt7uRfJX8QUs4suhyU8p2M6DoUDrJyWBa8LLZsg",
+        "tokenCode": "AMZNX"
+      },
+      {
+        "contractAddress": "XsCPL9dNWBMvFtTmwcCA5v3xWPSMEBCszbQdiLLq6aN",
+        "tokenCode": "GOOGLX"
+      },
+      {
+        "contractAddress": "XsqE9cRRpzxcGKDXj1BJ7Xmg4GRhZoyY1KpmGSxAWT2",
+        "tokenCode": "MCDX"
+      },
+      {
+        "contractAddress": "XsDoVfqeBukxuZHWhdvWHBhgEHjGNst4MLodqsJHzoB",
+        "tokenCode": "TSLAX"
+      },
+      {
+        "contractAddress": "a3W4qutoEJA4232T2gwZUfgYJTetr96pU4SJMwppump",
+        "tokenCode": "WHITEWHALE"
+      },
+      {
+        "contractAddress": "Xs3oZwbHvqis4NYcf4YKWmEia2eC84wSiVrcYcTqpH8",
+        "tokenCode": "SPCXX"
+      },
+      {
+        "contractAddress": "SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfgq",
+        "tokenCode": "SLX"
+      }
+    ]
+  ],
+  [
+    "SONIC",
+    [
+      {
+        "contractAddress": "0x29219dd400f2bf60e5a23d13be72b486d4038894",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "S"
+      }
+    ]
+  ],
+  [
+    "SUI",
+    [
+      {
+        "contractAddress": "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
+        "tokenCode": "USDC"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "SUI"
+      },
+      {
+        "contractAddress": "0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS",
+        "tokenCode": "CETUS"
+      },
+      {
+        "contractAddress": "0x5d1f47ea69bb0de31c313d7acf89b890dbb8991ea8e03c6c355171f84bb1ba4a::turbos::TURBOS",
+        "tokenCode": "TURBOS"
+      },
+      {
+        "contractAddress": "0xa99b8952d4f7d947ea77fe0ecdcc9e5fc0bcab2841d6e2a5aa00c3044e5544b5::navx::NAVX",
+        "tokenCode": "NAVX"
+      },
+      {
+        "contractAddress": "0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6::sca::SCA",
+        "tokenCode": "SCA"
+      },
+      {
+        "contractAddress": "0x706fa7723231e13e8d37dad56da55c027f3163094aa31c867ca254ba0e0dc79f::artfi::ARTFI",
+        "tokenCode": "ARTFI"
+      },
+      {
+        "contractAddress": "0x8993129d72e733985f7f1a00396cbd055bad6f817fee36576ce483c8bbb8b87b::sudeng::SUDENG",
+        "tokenCode": "HIPPO"
+      },
+      {
+        "contractAddress": "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP",
+        "tokenCode": "DEEP"
+      },
+      {
+        "contractAddress": "0x5145494a5f5100e645e4b0aa950fa6b68f614e8c59e17bc5ded3495123a79178::ns::NS",
+        "tokenCode": "NS"
+      },
+      {
+        "contractAddress": "0xe1b45a0e641b9955a20aa0ad1c1f4ad86aad8afb07296d4085e349a50e90bdca::blue::BLUE",
+        "tokenCode": "BLUE"
+      },
+      {
+        "contractAddress": "0xf22da9a24ad027cccb5f2d496cbe91de953d363513db08a3a734d361c7c17503::LOFI::LOFI",
+        "tokenCode": "LOFI"
+      },
+      {
+        "contractAddress": "0x1ef4c0b20340b8c6a59438204467ca71e1e7cbe918526f9c2c6c5444517cd5ca::chirp::CHIRP",
+        "tokenCode": "CHIRP"
+      },
+      {
+        "contractAddress": "0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL",
+        "tokenCode": "WAL"
+      },
+      {
+        "contractAddress": "0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL",
+        "tokenCode": "HAEDAL"
+      },
+      {
+        "contractAddress": "0x4c981f3ff786cdb9e514da897ab8a953647dae2ace9679e8358eec1e3e8871ac::dmc::DMC",
+        "tokenCode": "DMC"
+      },
+      {
+        "contractAddress": "0x7262fb2f7a3a14c888c438a3cd9b912469a58cf60f367352c46584262e8299aa::ika::IKA",
+        "tokenCode": "IKA"
+      },
+      {
+        "contractAddress": "0x1a8f4bc33f8ef7fbc851f156857aa65d397a6a6fd27a7ac2ca717b51f2fd9489::alkimi::ALKIMI",
+        "tokenCode": "ALKIMI"
+      },
+      {
+        "contractAddress": "0x0a48f85a3905cfa49a652bdb074d9e9fabad27892d54afaa5c9e0adeb7ac3cdf::swarm_network_token::SWARM_NETWORK_TOKEN",
+        "tokenCode": "TRUTH"
+      },
+      {
+        "contractAddress": "0x97c7571f4406cdd7a95f3027075ab80d3e9c937c2a567690d31e14ab1872ccee::xmn::XMN",
+        "tokenCode": "XMN"
+      },
+      {
+        "contractAddress": "0x35169bc93e1fddfcf3a82a9eae726d349689ed59e4b065369af8789fe59f8608::mmt::MMT",
+        "tokenCode": "MMT"
+      },
+      {
+        "contractAddress": "0xee962a61432231c2ede6946515beb02290cb516ad087bb06a731e922b2a5f57a::us::US",
+        "tokenCode": "US"
+      }
+    ]
+  ],
+  [
+    "TELOS",
+    [
+      {
+        "contractAddress": "eosio.token",
+        "tokenCode": "TLOS"
+      }
+    ]
+  ],
+  [
+    "TON",
+    [
+      {
+        "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "GRAM"
+      },
+      {
+        "contractAddress": "EQAIb6KmdfdDR7CN1GBqVJuP25iCnLKCvBlJ07Evuu2dzP5f",
+        "tokenCode": "USDE"
+      },
+      {
+        "contractAddress": "EQAvlWFDxGF2lXm67y4yzC17wYKD9A0guwPkMs1gOsM__NOT",
+        "tokenCode": "NOT"
+      },
+      {
+        "contractAddress": "EQCvxJy4eG8hyHBFsZ7eePxrRsUQSFE_jpptRAYBmcG_DOGS",
+        "tokenCode": "DOGS"
+      },
+      {
+        "contractAddress": "EQD-cvR0Nz6XAyRBvbhz-abTrRC6sI5tvHvvpeQraV9UAAD7",
+        "tokenCode": "CATI"
+      },
+      {
+        "contractAddress": "EQAJ8uWd7EBqsmpSWaRdf_I-8R8-XHwh3gsNKhy-UrdrPcUo",
+        "tokenCode": "HMSTR"
+      },
+      {
+        "contractAddress": "EQCuPm01HldiduQ55xaBF_1kaW_WAUy5DHey8suqzU_MAJOR",
+        "tokenCode": "MAJOR"
+      },
+      {
+        "contractAddress": "EQDWXjnVWheFemaAaFn-Cp4nDehvGllrXOZ8wqHm8sDEwn_c",
+        "tokenCode": "DUCK"
+      },
+      {
+        "contractAddress": "EQA1R_LuQCLHlMgOo1S4G7Y7W1cd0FrAkbA10Zq7rddKxi9k",
+        "tokenCode": "XAUT"
+      },
+      {
+        "contractAddress": "EQCAj5oiRRrXokYsg_B-e0KG9xMwh5upr5I8HQzErm0_BLUM",
+        "tokenCode": "BLUM"
+      },
+      {
+        "contractAddress": "EQBE_gBrU3mPI9hHjlJoR_kYyrhQgyCFD6EUWfa42W8T7EBP",
+        "tokenCode": "TAC"
+      }
+    ]
+  ],
+  [
+    "TRX",
+    [
+      {
+        "contractAddress": "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
+        "tokenCode": "WIN"
+      },
+      {
+        "contractAddress": "TAFjULxiVgT4qWk6UZwjqwZXTSaGaqnVp4",
+        "tokenCode": "BTT"
+      },
+      {
+        "contractAddress": "TWcDDx1Q6QEoBrJi9qehtZnD4vcXXuVLer",
+        "tokenCode": "KPOL"
+      },
+      {
+        "contractAddress": "TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9",
+        "tokenCode": "JST"
+      },
+      {
+        "contractAddress": "TSSMHYeV2uE9qYH95DqyoCuNCzEL1NvU3S",
+        "tokenCode": "SUN"
+      },
+      {
+        "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+        "tokenCode": "USDT"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "TRX"
+      },
+      {
+        "contractAddress": "TFczxzPhnThNSqr5by8tvxsdCFRRz6cPNq",
+        "tokenCode": "NFT"
+      },
+      {
+        "contractAddress": "TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz",
+        "tokenCode": "USDD"
+      },
+      {
+        "contractAddress": "TUpMhErZL2fhh4sVNULAbNKLokS4GjC1F4",
+        "tokenCode": "TUSD"
+      },
+      {
+        "contractAddress": "TUPM7K8REVzD2UdV4R5fe5M8XbnR2DdoJ6",
+        "tokenCode": "HTX"
+      },
+      {
+        "contractAddress": "TXL6rJbvmjD46zeN1JssfgxvSo99qC8MRT",
+        "tokenCode": "SUNDOG"
+      },
+      {
+        "contractAddress": "TPFqcBAaaUMCSVRCqPaQ9QnzKhmuoLR6Rc",
+        "tokenCode": "USD1"
+      }
+    ]
+  ],
+  [
+    "WAXP",
+    [
+      {
+        "contractAddress": "eosio.token",
+        "tokenCode": "WAX"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "WAXP"
+      }
+    ]
+  ],
+  [
+    "XEC",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "XEC"
+      }
+    ]
+  ],
+  [
+    "XLM",
+    [
+      {
+        "contractAddress": "GDM4RQUQQUVSKQA7S6EM7XBZP3FCGH4Q7CL6TABQ7B2BEJ5ERARM2M5M",
+        "tokenCode": "VELO"
+      },
+      {
+        "contractAddress": null,
+        "tokenCode": "XLM"
+      }
+    ]
+  ],
+  [
+    "XMR",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "XMR"
+      }
+    ]
+  ],
+  [
+    "XRP",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "XRP"
+      },
+      {
+        "contractAddress": "524C555344000000000000000000000000000000",
+        "tokenCode": "RLUSD"
+      }
+    ]
+  ],
+  [
+    "XTZ",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "XTZ"
+      },
+      {
+        "contractAddress": "KT1XnTn74bUtxHfDtBmm2bGZAQfhPbvKWR8o",
+        "tokenCode": "USDT"
+      }
+    ]
+  ],
+  [
+    "ZEC",
+    [
+      {
+        "contractAddress": null,
+        "tokenCode": "ZEC"
+      }
+    ]
+  ],
+  [
+    "ZKS20",
+    [
+      {
+        "contractAddress": "0x5a7d6b2f92c77fad6ccabd7ee0624e64907eaf3e",
+        "tokenCode": "ZK"
+      }
+    ]
+  ]
+]

--- a/test/swapter.test.ts
+++ b/test/swapter.test.ts
@@ -1,0 +1,451 @@
+import { sub } from 'biggystring'
+import { assert } from 'chai'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyWallet,
+  EdgeSpendInfo,
+  EdgeSwapPlugin,
+  EdgeSwapRequest,
+  EdgeTransaction
+} from 'edge-core-js/types'
+import { describe, it } from 'mocha'
+
+import { makeSwapterPlugin } from '../src/swap/central/swapter'
+
+const ETH_ADDRESS = '0x9A5c4A9F9E6f3fC7f8E1B8B0C9d5e6A7B8C9d0E1'
+const LTC_ADDRESS = 'LZ4hqRRHuCEUZaKfDrpvJ4NCFVBTFVQzcU'
+const DEPOSIT_ADDRESS = '0x1111111111111111111111111111111111111111'
+const ZEC_UNIFIED_ADDRESS = 'u1qqqqq0unifiedzcashaddress'
+const ZEC_TRANSPARENT_ADDRESS = 't1XyZtransparentzcashaddress'
+
+/** What the Ethereum engine holds back for the network fee. */
+const ETH_FEE = '196600000000000'
+
+/**
+ * The pair's live range in ETH, and the same bounds in native wei. Both bounds
+ * carry more decimals than a whole-wei amount, so they exercise the inward
+ * rounding the plugin applies: the minimum rounds up and the maximum down.
+ */
+const RANGE_MIN = '0.0160060'
+const RANGE_MAX = '5239.5248798'
+const RANGE_MIN_NATIVE = '16006000000000000'
+const RANGE_MAX_NATIVE = '5239524879800000000000'
+
+const IN_RANGE_NATIVE = '100000000000000000' // 0.1 ETH
+const BELOW_MIN_NATIVE = '15000000000000000' // 0.015 ETH
+const ABOVE_MAX_NATIVE = '9999000000000000000000' // 9999 ETH
+
+interface FakeWalletOpts {
+  pluginId: string
+  currencyCode: string
+  address: string
+  multiplier: string
+  balanceMap?: Map<string | null, string>
+  spendLog?: EdgeSpendInfo[]
+  /** Overrides the single-address default, in engine order. */
+  addresses?: Array<{ addressType: string; publicAddress: string }>
+}
+
+const makeFakeWallet = (opts: FakeWalletOpts): EdgeCurrencyWallet => {
+  const {
+    address,
+    addresses = [{ addressType: 'publicAddress', publicAddress: address }],
+    balanceMap = new Map(),
+    currencyCode,
+    multiplier,
+    pluginId,
+    spendLog = []
+  } = opts
+
+  const currencyInfo = {
+    pluginId,
+    currencyCode,
+    denominations: [{ name: currencyCode, multiplier }]
+  }
+
+  return ({
+    id: `${pluginId}-wallet`,
+    balanceMap,
+    currencyInfo,
+    currencyConfig: {
+      // `SwapCurrencyError` reads the pluginId through here.
+      currencyInfo,
+      allTokens: {}
+    },
+    async getAddresses() {
+      return addresses
+    },
+    async getMaxSpendable(spendInfo: EdgeSpendInfo) {
+      spendLog.push(spendInfo)
+      const balance = balanceMap.get(spendInfo.tokenId) ?? '0'
+      return spendInfo.tokenId == null ? sub(balance, ETH_FEE) : balance
+    },
+    async makeSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
+      spendLog.push(spendInfo)
+      return ({
+        networkFee: '0',
+        savedAction: spendInfo.savedAction,
+        assetAction: spendInfo.assetAction,
+        tokenId: spendInfo.tokenId
+      } as unknown) as EdgeTransaction
+    }
+  } as unknown) as EdgeCurrencyWallet
+}
+
+/** A non-ok body the fake `fetchCors` returns from the create endpoint. */
+type CreateError = Record<string, unknown> | null
+
+interface FakeIoLog {
+  /** Every URI the plugin requested, in order. */
+  uris: string[]
+  /** Parsed request bodies sent to the create endpoint. */
+  createBodies: Array<Record<string, any>>
+}
+
+/**
+ * A `/data/coins` row, in Swapter's shape: an asset listed on one network for
+ * both directions. The plugin keeps only rows it can both deposit and withdraw
+ * on a network this mapping lists.
+ */
+const coinRow = (
+  currency: string,
+  network: string
+): Record<string, unknown> => ({
+  currency,
+  networks: {
+    deposit: [{ network, contract: null }],
+    withdraw: [{ network, contract: null }]
+  }
+})
+
+/** Enough of a live snapshot to cover the pairs these cases quote. */
+const COINS = {
+  assets: [coinRow('ETH', 'ETH'), coinRow('LTC', 'LTC'), coinRow('ZEC', 'ZEC')]
+}
+
+/**
+ * Canned Swapter responses. `emptyCoins` reproduces a provider answering 200
+ * with nothing usable, which the plugin must treat as an outage rather than as
+ * an unsupported pair.
+ */
+const makeFakeIo = (
+  log: FakeIoLog,
+  createError: CreateError = null,
+  emptyCoins: boolean = false
+): { fetchCors: Function } => ({
+  fetchCors: async (uri: string, opts: { body?: string }) => {
+    log.uris.push(uri)
+
+    const ok = (body: unknown): unknown => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body)
+    })
+
+    if (uri.endsWith('/data/coins')) {
+      return ok(emptyCoins ? { assets: [] } : COINS)
+    }
+
+    if (uri.endsWith('/adapter/edge/swap/deposit-range')) {
+      return ok({ min: RANGE_MIN, max: RANGE_MAX })
+    }
+
+    // Anything else must be the create call, and the assertions below check it
+    // reached the adapter route rather than the `/v2` original.
+    log.createBodies.push(JSON.parse(opts.body ?? '{}'))
+
+    if (createError != null) {
+      return {
+        ok: false,
+        status: 400,
+        json: async () => createError,
+        text: async () => JSON.stringify(createError)
+      }
+    }
+
+    return ok({
+      uid: 'order-1',
+      deposit: { address: DEPOSIT_ADDRESS, memo: null },
+      withdraw: { amount: { expected: '2.045' } }
+    })
+  }
+})
+
+const makePlugin = (
+  log: FakeIoLog,
+  createError: CreateError = null,
+  emptyCoins: boolean = false
+): EdgeSwapPlugin =>
+  makeSwapterPlugin(({
+    io: makeFakeIo(log, createError, emptyCoins),
+    initOptions: { apiKey: 'test-key' },
+    log: { warn() {} }
+  } as unknown) as EdgeCorePluginOptions)
+
+const makeLog = (): FakeIoLog => ({ uris: [], createBodies: [] })
+
+const makeEthWallet = (
+  balanceMap?: Map<string | null, string>,
+  spendLog?: EdgeSpendInfo[]
+): EdgeCurrencyWallet =>
+  makeFakeWallet({
+    pluginId: 'ethereum',
+    currencyCode: 'ETH',
+    address: ETH_ADDRESS,
+    multiplier: '1000000000000000000',
+    balanceMap,
+    spendLog
+  })
+
+const makeLtcWallet = (): EdgeCurrencyWallet =>
+  makeFakeWallet({
+    pluginId: 'litecoin',
+    currencyCode: 'LTC',
+    address: LTC_ADDRESS,
+    multiplier: '100000000'
+  })
+
+/**
+ * A Zcash wallet in engine order: the unified address first, which is what a
+ * bare `getAddress` would pick.
+ */
+const makeZecWallet = (): EdgeCurrencyWallet =>
+  makeFakeWallet({
+    pluginId: 'zcash',
+    currencyCode: 'ZEC',
+    address: ZEC_UNIFIED_ADDRESS,
+    multiplier: '100000000',
+    addresses: [
+      { addressType: 'unifiedAddress', publicAddress: ZEC_UNIFIED_ADDRESS },
+      {
+        addressType: 'transparentAddress',
+        publicAddress: ZEC_TRANSPARENT_ADDRESS
+      }
+    ]
+  })
+
+const makeRequest = (
+  nativeAmount: string,
+  overrides: Partial<EdgeSwapRequest> = {}
+): EdgeSwapRequest =>
+  (({
+    fromWallet: makeEthWallet(),
+    fromTokenId: null,
+    toWallet: makeLtcWallet(),
+    toTokenId: null,
+    nativeAmount,
+    quoteFor: 'from',
+    ...overrides
+  } as unknown) as EdgeSwapRequest)
+
+const fetchQuote = async (
+  plugin: EdgeSwapPlugin,
+  request: EdgeSwapRequest
+): Promise<unknown> =>
+  await plugin.fetchSwapQuote(request, undefined, { infoPayload: {} })
+
+const expectError = async (
+  promise: Promise<unknown>
+): Promise<{ name: string; nativeMax?: string; nativeMin?: string }> => {
+  try {
+    await promise
+  } catch (error: unknown) {
+    return error as { name: string; nativeMax?: string; nativeMin?: string }
+  }
+  throw new Error('Expected the quote to throw')
+}
+
+describe('swapter', function () {
+  it('uses the Edge adapter endpoints, not the /v2 originals', async function () {
+    const log = makeLog()
+    await fetchQuote(makePlugin(log), makeRequest(IN_RANGE_NATIVE))
+
+    // The adapter routes serialize amounts as strings, where `/v2` returns
+    // unquoted JSON numbers that lose precision in `JSON.parse`. The range
+    // route is also authoritative: the `/v2/swap/min-amount` floor it replaced
+    // is LOWER than the one create enforces, so quoting against that produced
+    // orders the provider then rejected.
+    assert.isTrue(
+      log.uris.some(uri => uri.endsWith('/adapter/edge/swap/deposit-range'))
+    )
+    assert.isTrue(
+      log.uris.some(uri => uri.endsWith('/adapter/edge/swap/create'))
+    )
+    assert.isFalse(log.uris.some(uri => uri.includes('/v2/swap/')))
+  })
+
+  it('rejects an amount below the range minimum', async function () {
+    const error = await expectError(
+      fetchQuote(makePlugin(makeLog()), makeRequest(BELOW_MIN_NATIVE))
+    )
+
+    assert.equal(error.name, 'SwapBelowLimitError')
+    assert.equal(error.nativeMin, RANGE_MIN_NATIVE)
+  })
+
+  it('rejects an amount above the range maximum', async function () {
+    const log = makeLog()
+    const error = await expectError(
+      fetchQuote(makePlugin(log), makeRequest(ABOVE_MAX_NATIVE))
+    )
+
+    assert.equal(error.name, 'SwapAboveLimitError')
+    assert.equal(error.nativeMax, RANGE_MAX_NATIVE)
+    // The ceiling is known before any order exists, so no create is spent.
+    assert.lengthOf(log.createBodies, 0)
+  })
+
+  it('clamps a max swap through getMaxSpendable instead of the ceiling', async function () {
+    // The probe quotes the whole PRE-fee balance to discover what is spendable.
+    // Enforcing the ceiling there would throw on an amount the user never asked
+    // to send, so only the real quote enforces it.
+    const spendLog: EdgeSpendInfo[] = []
+    const balance = '1000000000000000000' // 1 ETH, inside the range
+    const request = makeRequest('0', {
+      fromWallet: makeEthWallet(new Map([[null, balance]]), spendLog),
+      quoteFor: 'max'
+    })
+
+    const quote = (await fetchQuote(makePlugin(makeLog()), request)) as {
+      fromNativeAmount: string
+    }
+
+    assert.equal(quote.fromNativeAmount, sub(balance, ETH_FEE))
+    // The fee-estimation probe targets the user's own address, so it must opt
+    // out of the engine's spend checks; the real order must not.
+    const [probeSpend] = spendLog
+    assert.equal(probeSpend.skipChecks, true)
+    assert.equal(probeSpend.spendTargets[0].publicAddress, ETH_ADDRESS)
+  })
+
+  it('maps the create above-maximum code to an above-limit error', async function () {
+    // The range moves with the rate, so an amount that cleared the range check
+    // can still be rejected by `create`. Swapter now distinguishes the two
+    // bounds by code, where both used to share `factory:6`.
+    const log = makeLog()
+    const error = await expectError(
+      fetchQuote(
+        makePlugin(log, {
+          error: {
+            code: 'io.swapter.controller.swap.factory:9',
+            message:
+              'Requested deposit amount is greater than allowed maximum.',
+            max: RANGE_MAX
+          }
+        }),
+        makeRequest(IN_RANGE_NATIVE)
+      )
+    )
+
+    assert.equal(error.name, 'SwapAboveLimitError')
+    assert.equal(error.nativeMax, RANGE_MAX_NATIVE)
+    // A limit applies to both swap types, so the fixed-rate rejection must not
+    // spend a second create on the floating fallback.
+    assert.lengthOf(log.createBodies, 1)
+  })
+
+  // create namespaces its unsupported-pair codes, where the deposit range
+  // answers a bare service code, so both vocabularies have to be recognised.
+  const UNSUPPORTED_PAIR_CASES = [
+    [
+      'io.swapter.controller.swap.factory:1',
+      'Networks for specified coin does not exist.'
+    ],
+    [
+      'io.swapter.controller.swap.factory:2',
+      'Specified deposit network does not exist.'
+    ],
+    [
+      'io.swapter.controller.swap.factory:3',
+      'Specified withdraw network does not exist.'
+    ],
+    ['1', 'Deposit coin and network combination does not exists.']
+  ]
+
+  for (const [code, message] of UNSUPPORTED_PAIR_CASES) {
+    it(`treats create code ${code} as an unsupported pair, with no float retry`, async function () {
+      const log = makeLog()
+      const error = await expectError(
+        fetchQuote(
+          makePlugin(log, { error: { code, message } }),
+          makeRequest(IN_RANGE_NATIVE)
+        )
+      )
+
+      assert.equal(error.name, 'SwapCurrencyError')
+      assert.lengthOf(log.createBodies, 1)
+    })
+  }
+
+  it('fails the quote when the ticker map is empty, instead of reporting an unsupported pair', async function () {
+    // A 200 carrying no usable assets is a provider outage. Mainnet codes come
+    // from the wallets' own `currencyInfo`, so without this guard the quote
+    // would proceed and only token pairs would fail, as `SwapCurrencyError`.
+    const log = makeLog()
+    const error = await expectError(
+      fetchQuote(makePlugin(log, null, true), makeRequest(IN_RANGE_NATIVE))
+    )
+
+    assert.notEqual(error.name, 'SwapCurrencyError')
+    assert.lengthOf(log.createBodies, 0)
+  })
+
+  it('sends the transparent address for Zcash, not the unified default', async function () {
+    // The engine lists the unified address first, and a CEX that cannot pay or
+    // refund one strands the deposit.
+    const log = makeLog()
+    await fetchQuote(
+      makePlugin(log),
+      makeRequest(IN_RANGE_NATIVE, {
+        fromWallet: makeEthWallet(),
+        toWallet: makeZecWallet()
+      })
+    )
+
+    const [createBody] = log.createBodies
+    assert.equal(createBody.withdraw.address, ZEC_TRANSPARENT_ADDRESS)
+  })
+
+  it('maps a bound-less limit code, so the fallback does not retry it', async function () {
+    // Swapter does not always echo the bound it rejected against. Requiring one
+    // dropped the rejection to a generic error, which is not pair-level, so the
+    // float fallback spent a second create on the same doomed amount.
+    const log = makeLog()
+    const error = await expectError(
+      fetchQuote(
+        makePlugin(log, {
+          error: {
+            code: 'io.swapter.controller.swap.factory:6',
+            message: 'Requested deposit amount is lower than allowed minimum.'
+          }
+        }),
+        makeRequest(IN_RANGE_NATIVE)
+      )
+    )
+
+    assert.equal(error.name, 'SwapBelowLimitError')
+    assert.equal(error.nativeMin, '')
+    assert.lengthOf(log.createBodies, 1)
+  })
+
+  it('maps the create below-minimum code to a below-limit error', async function () {
+    const log = makeLog()
+    const error = await expectError(
+      fetchQuote(
+        makePlugin(log, {
+          error: {
+            code: 'io.swapter.controller.swap.factory:6',
+            message: 'Requested deposit amount is lower than allowed minimum.',
+            min: RANGE_MIN
+          }
+        }),
+        makeRequest(IN_RANGE_NATIVE)
+      )
+    )
+
+    assert.equal(error.name, 'SwapBelowLimitError')
+    assert.equal(error.nativeMin, RANGE_MIN_NATIVE)
+    assert.lengthOf(log.createBodies, 1)
+  })
+})

--- a/test/testconfig.ts
+++ b/test/testconfig.ts
@@ -117,6 +117,11 @@ export const asTestConfig = asObject({
       quiknodeApiKey: asOptional(asString, '')
     }).withRest
   ),
+  SWAPTER_INIT: asCorePluginInit(
+    asObject({
+      apiKey: asOptional(asString, '')
+    }).withRest
+  ),
   SWAPUZ_INIT: asCorePluginInit(
     asObject({
       apiKey: asOptional(asString, '')


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1216571782597915

Adds **Swapter** as a centralized swap provider.

This recreates partner PR #455 (by @markovo4, from `markovo4/edge-exchange-plugins`) on an
EdgeApp branch so it can run CI, rebased from its `v2.46.0` merge-base onto current
`master`. The plugin design, mapping and test cases started as the partner's work; this
branch brings the integration up to current conventions, moves it onto Swapter's
Edge-specific adapter routes, and reconciles the mapping against the live asset list.

#### How the plugin works

**Endpoints.** Quotes use Swapter's Edge adapter routes,
`POST /adapter/edge/swap/deposit-range` and `POST /adapter/edge/swap/create`, rather than
the `/v2` originals. That is not a cosmetic swap. The adapter routes serialize every
numeric field as a string, where `/v2` returns unquoted JSON numbers that lose their low
digits in `JSON.parse` (an 18-decimal deposit round-trips exactly on the adapter route and
does not on `/v2`). And `deposit-range` is authoritative where `/v2/swap/min-amount` was
not: `min-amount` reported a floor BELOW the one create actually enforces, so an amount
could clear the plugin's own check and then be rejected by create.

**Rate type.** The plugin asks for a fixed-rate order first and falls back to a floating
one, which is the convention the sibling central plugins follow. Swapter spells the fixed type
`fix`, not `fixed`; an unrecognized value is not rejected as a bad request but answered
with HTTP 500, which is indistinguishable from a pair Swapter genuinely cannot fix, so the
wrong spelling silently downgraded every quote to float. The fallback still runs for pairs
that really cannot be fixed.

**Bounds and errors.** `deposit-range` supplies both a floor and a ceiling, and both round
INWARD into native units (minimums up, maximums down) so rounding can never widen the range
past what Swapter accepts. Create's own limit codes (`factory:6` below, `factory:9` above)
map to `SwapBelowLimitError` / `SwapAboveLimitError` whether or not Swapter echoes the
bound it rejected against. Unsupported-pair codes differ between the two routes, so both
vocabularies are recognised: `deposit-range` answers a bare service code, create namespaces
its own (`factory:1`/`2`/`3`). Errors are matched on `name` rather than `instanceof`,
because edge-core-js's error constructors return a plain `Error` carrying a `name` and
`instanceof` against them is permanently false.

**Max swaps.** The quote routes through `getMaxSwappable` like every other central plugin.
The fee probe targets the user's own refund address with `skipChecks: true`, so pricing a
max swap creates no abandoned order and EVM wallets do not fail with `SpendToSelfError`.
Exactly one order is created per quote.

**Assets.** `src/mappings/swapter.ts` maps each Edge plugin ID to a Swapter network name,
and `/data/coins` (fetched unauthenticated, since that route answers 401 for any
`X-API-KEY`) supplies the per-network ticker set used to resolve tokens. Every entry is
verified against the live list rather than reasoned about: a stale code is caught by no type
and no test, and simply fails at quote time. Three chains need a `SPECIAL_MAINNET_CASES`
override because Swapter's asset code differs from Edge's `currencyCode`: native TON is
`GRAM`, Bitcoin SV is `BCHSV`, and the EOS network carries only Vaulta's `A`. zkSync is
mapped for its `ZK` token but its native ETH is blocked through `INVALID_TOKEN_IDS`, since
Swapter does not list it. An empty ticker map is treated as a provider outage and fails the
quote, rather than being cached for the hour and reported as an unsupported pair.

`test/partnerJson/swapterMap.json` is regenerated from a current `/data/coins` snapshot
(44 networks, 829 tickers).

#### Known limitations

These are gaps against `API_REQUIREMENTS.md` that the plugin cannot close on its own,
because they need changes to Swapter's adapter. They are recorded here rather than worked
around:

- **Assets are identified by ticker plus network name**, not by chain plus contract. The
  adapter accepts only `coin` and `network`, so the plugin has no contract field to send
  even though it resolves contracts locally to build the ticker map.
- **No numeric EVM `chainId`.** EVM chains are keyed by Swapter's own network names, so
  adding a chain (or surviving a rename) needs a mapping edit.
- **Quotes are deposit-amount only**, so exact-receive (`to`) quotes are unsupported and
  `fetchQuoteBase` rejects them. `max` is unaffected: `getMaxSwappable` rewrites it into a
  `from` quote.
- **Errors arrive one at a time** as `{ error: { code, message, min?, max? } }`, not as an
  `errors` array, so Edge cannot prioritize among all applicable errors.
- **Unactivated XRP/HBAR destinations** are unconfirmed: nothing in the API states whether
  Swapter bundles account activation into the withdrawal.
- **`info.type: "fixed"` still answers HTTP 500** rather than a structured 4xx, which is why
  the fixed-rate attempt cannot be distinguished from a provider outage and the float
  fallback exists.

#### Testing

`verify-repo.sh` passes (prepare, eslint, `tsc`, mocha). The suite includes
`test/swapter.test.ts` covering the adapter endpoints, both range bounds, the max-swap
probe carve-out, the create limit codes with and without an echoed bound, the
unsupported-pair codes from both routes, the empty-ticker-map failure, and the Zcash
transparent-address selection, plus the `partnerJson` cases asserting against the
regenerated live fixture.

**Swaps have been executed end to end in the app**, on the iOS simulator against the live
API with the real plugin linked in via `updot`. The most recent run was a max
DOGE to LTC swap: the quote scene rendered `481.55 DOGE ($33.81) to 0.739 LTC ($32.91)`
labelled *Powered by Swapter*, confirmed through the slider to the success scene, and the
transaction record reads `Swap Funds / Exchange:To LTC / 481.55488751 Ð (+2.568422 fee) /
Fixed Quote`, the `Fixed Quote` label confirming the `type: 'fix'` path rather than the
float fallback. Earlier rounds executed ETH (Arbitrum) to LTC, LTC to DOGE, LTC to DGB and
DGB to LTC, so both directions of the LTC pairs and several deposit assets have been
exercised. Screenshots are attached in a PR comment.

#### Follow-ups

- `swapter` is registered but not yet enabled anywhere: the info server serves no Swapter
  init options, so the GUI needs `SWAPTER_INIT` before it can surface.
- Consider a `mapctl` synchronizer for Swapter. `/data/coins` needs no API key, so it is a
  clean fit and would catch renames automatically instead of silently dropping a chain. Not
  done here because `mapctl update-mappings` constructs every provider's synchronizer
  eagerly and aborts without all of their API keys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New live swap provider that creates real orders and moves user funds via external API; complexity is high (error codes, fixed/float fallback, max-swap probe) but the design mirrors existing central plugins.
> 
> **Overview**
> **Adds Swapter** as a centralized swap provider: registers `makeSwapterPlugin` in `src/index.ts`, documents the release in `CHANGELOG.md`, and wires `SWAPTER_INIT` (`apiKey`) in test config.
> 
> The plugin (`src/swap/central/swapter.ts`) quotes via Swapter’s **Edge adapter** routes (`/adapter/edge/swap/deposit-range` and `/adapter/edge/swap/create`) instead of `/v2`, loads supported tokens from **unauthenticated** `/data/coins`, and maps Edge chains in `src/mappings/swapter.ts`. Quoting is **deposit-amount only** (`quoteFor: 'from'`); it tries **fixed** rate (`type: 'fix'`) then falls back to **float** when create rejects the fixed attempt without a pair/amount error. Deposit bounds are enforced from `deposit-range` (with inward rounding to native limits); API codes map to `SwapCurrencyError`, `SwapBelowLimitError`, and `SwapAboveLimitError`. **Max swaps** use a fee probe to the user’s refund address with `skipChecks`, then a single create order. Special cases include transparent **Zcash** addresses, `SPECIAL_MAINNET_CASES` (TON/BSV/EOS), and blocking native **zkSync** via `INVALID_TOKEN_IDS`.
> 
> **Tests:** `test/swapter.test.ts` covers adapter paths, limits, max swap, error codes, empty asset cache, and Zcash; `test/partnerJson` adds Swapter cases and a regenerated `swapterMap.json` fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d88d2132dbcbef6f88291eb92e9f013cfebbd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->