### PR TITLE
Fix Maya quotes for assets bridged from other chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Maya) Quote amounts for assets bridged from other chains are no longer scaled by the asset's own precision, which gave wrong estimates and metadata (a Dash to USDT quote was overestimated 100x).
+
 ## 2.51.0 (2026-07-13)
 
 - added: (Bridgeless) Optional `referralId` init option, included in EVM, Zano, and Bitcoin/BCH deposit payloads to attribute referral revenue.

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -62,17 +62,18 @@ export const EVM_TOKEN_SEND_GAS = '80000'
 export const THOR_LIMIT_UNITS = '100000000'
 export const AFFILIATE_FEE_BASIS_DEFAULT = '50'
 
-// Thornode normalizes every asset's amount to THOR_LIMIT_UNITS (1e8) in its
-// quote API. Mayanode instead expresses amounts in each asset's own native
-// precision (e.g. CACAO is 1e10, BTC is 1e8). Resolve the multiplier that
-// converts between an asset's exchange-denominated amount and the units the
-// node API expects for this swap.
-const getNodeLimitUnits = (
+// Both nodes normalize bridged assets to THOR_LIMIT_UNITS (1e8) in their quote
+// APIs, regardless of the asset's own precision. Mayanode's only exception is
+// MAYAChain's own assets, which it expresses in their native precision (CACAO
+// is 1e10, MAYA is 1e4). Resolve the multiplier that converts between an
+// asset's exchange-denominated amount and the units the node API expects.
+export const getNodeLimitUnits = (
   swapInfo: EdgeSwapInfo,
   wallet: EdgeCurrencyWallet,
   tokenId: EdgeTokenId
 ): string =>
-  swapInfo.pluginId === 'mayaprotocol'
+  swapInfo.pluginId === 'mayaprotocol' &&
+  wallet.currencyInfo.pluginId === 'mayachain'
     ? getTokenMultiplier(wallet, tokenId)
     : THOR_LIMIT_UNITS
 const NATIVE_IN_GWEI = '1000000000'

--- a/test/mayaprotocol.test.ts
+++ b/test/mayaprotocol.test.ts
@@ -1,0 +1,115 @@
+import { assert } from 'chai'
+import {
+  EdgeCurrencyWallet,
+  EdgeSwapInfo,
+  EdgeTokenId
+} from 'edge-core-js/types'
+import { describe, it } from 'mocha'
+
+import { getNodeLimitUnits } from '../src/swap/defi/thorchain/thorchainCommon'
+
+const mayaSwapInfo: EdgeSwapInfo = {
+  pluginId: 'mayaprotocol',
+  isDex: true,
+  displayName: 'Maya Protocol',
+  supportEmail: 'support@edge.app'
+}
+const thorSwapInfo: EdgeSwapInfo = {
+  pluginId: 'thorchain',
+  isDex: true,
+  displayName: 'Thorchain',
+  supportEmail: 'support@edge.app'
+}
+
+interface FakeToken {
+  tokenId: string
+  currencyCode: string
+  multiplier: string
+}
+
+const makeFakeWallet = (
+  pluginId: string,
+  currencyCode: string,
+  multiplier: string,
+  tokens: FakeToken[] = []
+): EdgeCurrencyWallet => {
+  const allTokens: {
+    [tokenId: string]: {
+      currencyCode: string
+      denominations: Array<{ name: string; multiplier: string }>
+    }
+  } = {}
+  for (const token of tokens) {
+    allTokens[token.tokenId] = {
+      currencyCode: token.currencyCode,
+      denominations: [
+        { name: token.currencyCode, multiplier: token.multiplier }
+      ]
+    }
+  }
+
+  // Only the fields getNodeLimitUnits/getTokenMultiplier read are needed:
+  return ({
+    currencyInfo: {
+      pluginId,
+      currencyCode,
+      denominations: [{ name: currencyCode, multiplier }]
+    },
+    currencyConfig: { allTokens }
+  } as unknown) as EdgeCurrencyWallet
+}
+
+const ethWallet = makeFakeWallet('ethereum', 'ETH', '1000000000000000000', [
+  { tokenId: 'usdttokenid', currencyCode: 'USDT', multiplier: '1000000' }
+])
+const dashWallet = makeFakeWallet('dash', 'DASH', '100000000')
+const mayachainWallet = makeFakeWallet('mayachain', 'CACAO', '10000000000', [
+  { tokenId: 'mayatokenid', currencyCode: 'MAYA', multiplier: '10000' }
+])
+
+describe(`getNodeLimitUnits`, function () {
+  // Mayanode normalizes bridged assets to 1e8 no matter their own precision,
+  // so these must NOT resolve to the asset's native multiplier. Using USDT's
+  // native 1e6 here over-estimated Maya quotes by 100x.
+  const bridgedCases: Array<[string, EdgeCurrencyWallet, EdgeTokenId]> = [
+    ['ethereum USDT token', ethWallet, 'usdttokenid'],
+    ['ethereum mainnet', ethWallet, null],
+    ['dash mainnet', dashWallet, null]
+  ]
+  for (const [name, wallet, tokenId] of bridgedCases) {
+    it(`maya uses 1e8 for ${name}`, function () {
+      assert.equal(
+        getNodeLimitUnits(mayaSwapInfo, wallet, tokenId),
+        '100000000'
+      )
+    })
+  }
+
+  // MAYAChain's own assets are the exception: Mayanode expresses those in
+  // their native precision.
+  it('maya uses native 1e10 for CACAO', function () {
+    assert.equal(
+      getNodeLimitUnits(mayaSwapInfo, mayachainWallet, null),
+      '10000000000'
+    )
+  })
+
+  it('maya uses native 1e4 for the MAYA token', function () {
+    assert.equal(
+      getNodeLimitUnits(mayaSwapInfo, mayachainWallet, 'mayatokenid'),
+      '10000'
+    )
+  })
+
+  // Thornode normalizes everything, including MAYAChain assets.
+  it('thorchain always uses 1e8', function () {
+    assert.equal(
+      getNodeLimitUnits(thorSwapInfo, ethWallet, 'usdttokenid'),
+      '100000000'
+    )
+    assert.equal(
+      getNodeLimitUnits(thorSwapInfo, mayachainWallet, null),
+      '100000000'
+    )
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Fixes [Swap (Maya) - Dash->USDT gives wrong estimate (and wrong metadata)](https://app.asana.com/0/1215088146871429/1216518039073159).

Maya quoted a Dash to USDT swap 100x too high (263 USDT shown instead of 2.63), and saved that same wrong number as the transaction's metadata. The reporter hit it on Dash to USDT, but as David noted on the task it is a general Maya issue: it affects every Maya swap whose asset is not natively 1e8.

#### Root cause

Mayanode normalizes assets bridged from other chains to `THOR_LIMIT_UNITS` (1e8) in its quote API, exactly as Thornode does. It expresses only MAYAChain's **own** assets in their native precision.

d57b048 ("Fix Maya CACAO source swaps") fixed CACAO by assuming Mayanode uses each asset's native precision for *everything*. That over-generalized, so any asset not natively 1e8 was scaled wrong:

| Asset | Native | What the code used | What Mayanode wants | Result |
|---|---|---|---|---|
| USDT / USDC | 1e6 | 1e6 | 1e8 | **100x over**-estimate (this bug) |
| ETH / ARB tokens | 1e18 | 1e18 | 1e8 | 1e10 under-estimate |
| DASH / BTC / ZEC / RUNE | 1e8 | 1e8 | 1e8 | correct by coincidence |
| CACAO | 1e10 | 1e10 | 1e10 | correct (d57b048's fix) |
| MAYA token | 1e4 | 1e4 | 1e4 | correct |

Dash, BTC, ZEC and RUNE happen to be natively 1e8, which is why this surfaced as a specific "Dash to USDT" report rather than a total Maya outage.

#### The fix

Restrict the native-precision branch in `getNodeLimitUnits` to wallets on the `mayachain` plugin. CACAO source swaps keep the behavior d57b048 gave them, and Thorchain is untouched (its multiplier already resolves to `THOR_LIMIT_UNITS`).

#### Evidence that Mayanode really uses 1e8 / 1e10

Verified against the live API rather than assumed:

- `GET /mayachain/quote/swap` for 1 DASH (`amount=100000000`) to `ETH.USDT-0XDAC…` returns `expected_amount_out: 3265422100`, which is 32.65 USDT at 1e8 (a sane DASH price). Dividing by USDT's native 1e6 gives 3265 — the reported 100x.
- `GET /cosmos/bank/v1beta1/supply` returns `cacao = 1000000000000000000` (exactly 100,000,000 CACAO at 1e10, Maya's documented supply) and `maya = 10000000000` (exactly 1,000,000 MAYA at 1e4). CACAO derived from the DASH pool at 1e10 prices it at $0.117 vs CoinGecko's $0.1224.

A unit test pins the whole matrix (Maya USDT/ETH/DASH to 1e8; Maya CACAO to 1e10; Maya MAYA to 1e4; Thorchain always 1e8) so the regression cannot silently return. It fails on the old predicate with `expected '1000000' to equal '100000000'`.

#### Testing

Executed the reporter's exact repro on the iOS simulator: a real Maya swap of 0.1913 DASH to USDT (Ethereum) from `My Dash 2` to `My Ether 4`, driven to the executed-swap success scene. Screenshots below.

Same pair, same amount, minutes apart on the same device:

| | Input | Quoted USDT |
|---|---|---|
| Before (released plugin) | 0.19119 DASH ($6.49) | **505.725** ($505.32) |
| After (this fix) | 0.19126 DASH ($6.50) | **5.054** ($5.05) |

Both halves of the task's passing criteria are covered: the Exchange scene estimate is correct, and the saved metadata in Exchange Details reads `Exchange 0.19124 Ð / To 5.053527 USDT (ETH)` where it would previously have read ~505.35.

The ~22% price impact on the "after" quote is Maya's fixed outbound fee (~1.4 USDT) against a deliberately small test swap sized just above the live floor of 0.165 DASH; it is not related to this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect quote scaling directly affects user-facing amounts and transaction metadata for Maya swaps on non-1e8 bridged assets; the change is localized to unit conversion but is user-visible and was previously wrong by large factors.
> 
> **Overview**
> Fixes **Maya Protocol** swap quotes and saved swap metadata that were wrong whenever the source or destination wallet was not on `mayachain` but the asset’s native decimals were not 1e8 (e.g. Dash → USDT showed ~100× too much USDT).
> 
> **`getNodeLimitUnits`** in `thorchainCommon` now uses each asset’s **native multiplier only** when the swap is Maya **and** the wallet is the `mayachain` plugin (CACAO / MAYA). For all other Maya legs—including Ethereum USDT, Dash, ETH, etc.—it uses **`THOR_LIMIT_UNITS` (1e8)**, matching Mayanode’s quote API. Thorchain behavior is unchanged (always 1e8). The helper is **exported** for tests.
> 
> Adds **`test/mayaprotocol.test.ts`** to lock in bridged vs native Maya cases and Thorchain’s 1e8 rule, plus an **Unreleased** CHANGELOG entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090b2240395a1829c6e92de15841795c26b0986f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->