### PR TITLE
Fix Maya quotes for assets not natively 1e8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Maya) Quote assets on external chains in 1e8 units, restoring quotes that regressed in 2.48.1. Maya stopped quoting any non-1e8-precision asset (e.g. USDT and ETH on Ethereum, ADA), either dropping itself from the quote list or returning a near-zero receive amount.
+
 ## 2.51.0 (2026-07-13)
 
 - added: (Bridgeless) Optional `referralId` init option, included in EVM, Zano, and Bitcoin/BCH deposit payloads to attribute referral revenue.

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -62,17 +62,20 @@ export const EVM_TOKEN_SEND_GAS = '80000'
 export const THOR_LIMIT_UNITS = '100000000'
 export const AFFILIATE_FEE_BASIS_DEFAULT = '50'
 
-// Thornode normalizes every asset's amount to THOR_LIMIT_UNITS (1e8) in its
-// quote API. Mayanode instead expresses amounts in each asset's own native
-// precision (e.g. CACAO is 1e10, BTC is 1e8). Resolve the multiplier that
-// converts between an asset's exchange-denominated amount and the units the
-// node API expects for this swap.
-const getNodeLimitUnits = (
+// Thornode and Mayanode both normalize amounts on external chains to
+// THOR_LIMIT_UNITS (1e8) in their quote API, regardless of the asset's own
+// precision: ETH.ETH, ETH.USDT and ADA.ADA are all quoted in 1e8 even though
+// they are natively 1e18, 1e6 and 1e6. Only Maya's own chain-native assets
+// keep their native precision (CACAO is 1e10, MAYA is 1e4). Resolve the
+// multiplier that converts between an asset's exchange-denominated amount and
+// the units the node API expects for this swap.
+export const getNodeLimitUnits = (
   swapInfo: EdgeSwapInfo,
   wallet: EdgeCurrencyWallet,
   tokenId: EdgeTokenId
 ): string =>
-  swapInfo.pluginId === 'mayaprotocol'
+  swapInfo.pluginId === 'mayaprotocol' &&
+  wallet.currencyInfo.pluginId === 'mayachain'
     ? getTokenMultiplier(wallet, tokenId)
     : THOR_LIMIT_UNITS
 const NATIVE_IN_GWEI = '1000000000'

--- a/test/thorchain.test.ts
+++ b/test/thorchain.test.ts
@@ -1,7 +1,15 @@
 import { assert } from 'chai'
+import {
+  EdgeCurrencyWallet,
+  EdgeSwapInfo,
+  EdgeTokenId
+} from 'edge-core-js/types'
 import { describe, it } from 'mocha'
 
-import { getVolatilitySpread } from '../src/swap/defi/thorchain/thorchainCommon'
+import {
+  getNodeLimitUnits,
+  getVolatilitySpread
+} from '../src/swap/defi/thorchain/thorchainCommon'
 
 describe(`getVolatilitySpread`, function () {
   it('bitcoin source', function () {
@@ -171,5 +179,109 @@ describe(`getVolatilitySpread`, function () {
       ]
     })
     assert.equal(result, '2')
+  })
+})
+
+describe(`getNodeLimitUnits`, function () {
+  const mayaSwapInfo: EdgeSwapInfo = {
+    pluginId: 'mayaprotocol',
+    isDex: true,
+    displayName: 'Maya Protocol',
+    supportEmail: 'support@edge.app'
+  }
+  const thorSwapInfo: EdgeSwapInfo = {
+    pluginId: 'thorchain',
+    isDex: true,
+    displayName: 'Thorchain',
+    supportEmail: 'support@edge.app'
+  }
+
+  const makeWallet = (
+    pluginId: string,
+    currencyCode: string,
+    multiplier: string,
+    tokens: {
+      [tokenId: string]: { currencyCode: string; multiplier: string }
+    } = {}
+  ): EdgeCurrencyWallet => {
+    const currencyInfo = {
+      currencyCode,
+      pluginId,
+      denominations: [{ name: currencyCode, multiplier }]
+    }
+    const allTokens: { [tokenId: string]: unknown } = {}
+    for (const tokenId of Object.keys(tokens)) {
+      allTokens[tokenId] = {
+        currencyCode: tokens[tokenId].currencyCode,
+        denominations: [
+          {
+            name: tokens[tokenId].currencyCode,
+            multiplier: tokens[tokenId].multiplier
+          }
+        ]
+      }
+    }
+    // Only the fields getNodeLimitUnits reads are needed:
+    return ({
+      currencyInfo,
+      currencyConfig: { allTokens }
+    } as unknown) as EdgeCurrencyWallet
+  }
+
+  const usdtTokenId: EdgeTokenId = 'dac17f958d2ee523a2206206994597c13d831ec7'
+  const ethWallet = makeWallet('ethereum', 'ETH', '1000000000000000000', {
+    [usdtTokenId]: { currencyCode: 'USDT', multiplier: '1000000' }
+  })
+  const adaWallet = makeWallet('cardano', 'ADA', '1000000')
+  const btcWallet = makeWallet('bitcoin', 'BTC', '100000000')
+  const mayaTokenId: EdgeTokenId = 'mayatokenid'
+  const cacaoWallet = makeWallet('mayachain', 'CACAO', '10000000000', {
+    [mayaTokenId]: { currencyCode: 'MAYA', multiplier: '10000' }
+  })
+
+  // Mayanode quotes assets on external chains in 1e8 regardless of the asset's
+  // own precision. Feeding it the native precision makes it quote the wrong
+  // amount (or error outright), which drops the provider from the quote list.
+  it('maya: external EVM mainnet coin uses 1e8, not its 1e18 precision', function () {
+    assert.equal(getNodeLimitUnits(mayaSwapInfo, ethWallet, null), '100000000')
+  })
+
+  it('maya: external EVM token uses 1e8, not its 1e6 precision', function () {
+    assert.equal(
+      getNodeLimitUnits(mayaSwapInfo, ethWallet, usdtTokenId),
+      '100000000'
+    )
+  })
+
+  it('maya: external non-EVM chain uses 1e8, not its 1e6 precision', function () {
+    assert.equal(getNodeLimitUnits(mayaSwapInfo, adaWallet, null), '100000000')
+  })
+
+  it('maya: external chain that is natively 1e8 uses 1e8', function () {
+    assert.equal(getNodeLimitUnits(mayaSwapInfo, btcWallet, null), '100000000')
+  })
+
+  // Maya's own chain-native assets keep their native precision:
+  it('maya: chain-native CACAO uses its 1e10 precision', function () {
+    assert.equal(
+      getNodeLimitUnits(mayaSwapInfo, cacaoWallet, null),
+      '10000000000'
+    )
+  })
+
+  it('maya: chain-native MAYA token uses its 1e4 precision', function () {
+    assert.equal(
+      getNodeLimitUnits(mayaSwapInfo, cacaoWallet, mayaTokenId),
+      '10000'
+    )
+  })
+
+  // Thornode normalizes everything to 1e8:
+  it('thorchain: always uses 1e8', function () {
+    assert.equal(
+      getNodeLimitUnits(thorSwapInfo, ethWallet, usdtTokenId),
+      '100000000'
+    )
+    assert.equal(getNodeLimitUnits(thorSwapInfo, btcWallet, null), '100000000')
   })
 })


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1216604091814363/f)

Maya stopped quoting USDT (Ethereum) to ETH, so the provider silently disappeared from the swap provider list. QA reported it as "I can't find Maya to verify this task" on staging 26071407.

**Root cause.** `getNodeLimitUnits`, added in d57b048 to fix CACAO source swaps, resolves the node's amount units as the asset's own native precision for every Maya asset. That is only true for Maya's *chain-native* assets. Mayanode, like Thornode, normalizes assets on **external chains to 1e8** regardless of their own precision. Measured against the live mayanode API:

| from_asset | native precision | units mayanode actually wants | result at native precision |
|---|---|---|---|
| `ETH.USDT` | 1e6 | **1e8** | error / garbage quote |
| `ETH.ETH` | 1e18 | **1e8** | garbage quote |
| `ADA.ADA` | 1e6 | **1e8** | error |
| `ARB.USDC` | 1e6 | **1e8** | error |
| `MAYA.CACAO` | 1e10 | **1e10** | correct |
| `MAYA.MAYA` | 1e4 | **1e4** | correct |

**Why the provider vanishes.** Quoting USDT with its 1e6 multiplier sends mayanode an amount 100x too small. For typical amounts it answers `HTTP 200` with a body of `{"error": "...not enough asset to pay for fees..."}`. Since `response.ok` is true, the existing "swap too small" branch is skipped, `asQuoteSwap` fails to clean, `getQuote` returns `undefined`, and `getBestQuote` throws `Could not get quote` — so the plugin drops out of the quote list entirely. Larger amounts survive but divide the receive amount by the destination's precision instead of 1e8, quoting 189.565 USDT to 0.0000000000000234 ETH.

**Fix.** Resolve the node units as the asset's own precision only for Maya's chain-native assets, preserving d57b048's CACAO fix, and use `THOR_LIMIT_UNITS` (1e8) everywhere else. Unit tests pin the convention per chain so it cannot silently regress a third time.

**Regression window.** d57b048 merged to master 2026-06-23 and first shipped in **2.48.1**. This is not related to #466 (the pending-metadata fix), which shipped in 2.50.0 and is confirmed working here.

### Test plan

Driven against the **live mayanode API** through the real plugin (`fetchSwapQuote`), same request both sides:

| USDT(ETH) 189.565 to ETH | `amount` sent to mayanode | `toNativeAmount` |
|---|---|---|
| before | `189565000` | `23430` (2.3e-14 ETH) |
| after | `18956500000` | `96324200000000000` (**0.0963242 ETH**) |

CACAO to BTC is byte-identical before and after (`amount=10000000000000`, 0.00185965 BTC), confirming d57b048's fix is preserved.

**In-app on the iOS sim** (edge-funds, USDT Ethereum to ETH, "My Ether 4"):

- **Pre-fix:** provider list shows Rango / Change NOW / Thorchain — **no Maya** (reproduces QA's report).
- **Post-fix:** **Maya Protocol appears** at 0.0043957 ETH.
- Executed a real Maya swap through to a pending transaction: metadata reads **USDT 10.008 / $9.99**, non-zero (the symptom of the original task), category `Exchange:To ETH`.
- On-chain confirmed: [`0xc271eb93...f85649`](https://www.mayascan.org/tx/0xc271eb936ccbddfa2eeb6ba6160bdcbca301744fb0d4b5de2309f96054f85649) to the Maya router `0xe3985E...B46d`, `depositWithExpiry`, mined.

`tsc`, eslint and `npm test` (40 passing, incl. 7 new) all pass via `verify-repo.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Thorchain/Maya quote amount scaling used in `calcSwapFrom`/`calcSwapTo`; wrong logic breaks Maya visibility or quoted receive amounts, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes a **2.48.1 regression** where Maya Protocol stopped appearing or returned nonsense quotes for swaps involving assets whose native precision is not 1e8 (e.g. **USDT/ETH on Ethereum**, **ADA**).
> 
> **`getNodeLimitUnits`** now uses each asset’s **native multiplier only when the swap wallet is Maya chain-native** (`mayaprotocol` + `mayachain` plugin). For all other chains it uses **`THOR_LIMIT_UNITS` (1e8)**, matching Mayanode’s quote API (same convention as Thornode for external assets). **CACAO/MAYA** on-chain behavior from the earlier CACAO fix is unchanged.
> 
> Adds **`getNodeLimitUnits` unit tests** and a **CHANGELOG** entry under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede94aecb395f7086ad5e8c5d464e01bcba6a033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->