### PR TITLE
Fix NYM max swaps from EVM wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: (NYM) Max swaps from EVM wallets no longer fail with "No enabled exchanges support". The fee-estimation probe targets the user's own address, which the engine rejected as a spend to self.
+- fixed: (NYM) Swaps whose amount is outside NYM's per-asset limits now report "below the limit" / "above the limit" instead of "No enabled exchanges support". NYM rejects an out-of-range amount before quoting, and the error was mapped to an unsupported-pair error that lost error ranking to other plugins.
 
 ## 2.52.0 (2026-07-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (NYM) Max swaps from EVM wallets no longer fail with "No enabled exchanges support". The fee-estimation probe targets the user's own address, which the engine rejected as a spend to self.
+
 ## 2.52.0 (2026-07-17)
 
 - added: (Bridgeless) Solana (native SOL) and TON (native) swaps to and from Zano, including referral id support.

--- a/src/swap/central/nym.ts
+++ b/src/swap/central/nym.ts
@@ -303,6 +303,14 @@ export function makeNymPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
         }
       ],
       networkFeeOption: 'high',
+      // This spend is never broadcast: it exists only so `getMaxSpendable` can
+      // price the network fee before the real order (and its payin address)
+      // exists. Its target is the user's own from-chain address, which engines
+      // that compare the spend target against their own public key reject with
+      // `SpendToSelfError` (every EVM chain, where the public key *is* the
+      // address). That threw out of `getMaxSwappable` and failed every max
+      // swap from an EVM wallet. The real order below keeps all checks.
+      skipChecks: true,
       assetAction: {
         assetActionType: 'swap'
       }

--- a/src/swap/central/nym.ts
+++ b/src/swap/central/nym.ts
@@ -108,8 +108,19 @@ const asNymOrder = asObject({
 // Error bodies come in two shapes:
 //   { errors: [{ error: 'InvalidRequest' | 'AssetNotSupported', message }] }
 //   { error: 'Quote rate limit exceeded ...' }
+// An amount outside a NYM asset's limits reports as one of the `errors` array
+// entries, carrying the boundary in native units for both sides:
+//   { errors: [{ error: 'UnderLimitError' | 'OverLimitError',
+//               sourceAmountLimit, destinationAmountLimit }] }
 const asNymErrorArray = asObject({
-  errors: asArray(asObject({ error: asString, message: asOptional(asString) }))
+  errors: asArray(
+    asObject({
+      error: asString,
+      message: asOptional(asString),
+      sourceAmountLimit: asOptional(asString),
+      destinationAmountLimit: asOptional(asString)
+    })
+  )
 })
 const asNymSimpleError = asObject({ error: asString })
 
@@ -174,6 +185,32 @@ export function makeNymPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       // Region / geographic restriction.
       if (/region|geo|country|blocked|jurisdiction/i.test(message)) {
         throw new SwapPermissionError(swapInfo, 'geoRestriction')
+      }
+      // Amount outside the asset's limits. NYM rejects this with a 400 BEFORE it
+      // returns a quote, so it never reaches the min/max check that a successful
+      // quote runs. Map it to the ranked limit errors: otherwise it falls
+      // through to `SwapCurrencyError`, which edge-core-js ranks BELOW an
+      // unrelated plugin's "unsupported pair", so a below-minimum balance
+      // surfaces as the misleading "No enabled exchanges support X to Y" (the
+      // in-app symptom on a native-EVM wallet whose whole balance is below the
+      // minimum, e.g. a small ETH balance on a max swap). The boundary side
+      // follows the request direction: a `to` quote is limited by the
+      // destination amount, everything else by the source amount.
+      const limitError = errorArray.errors.find(
+        e => e.error === 'UnderLimitError' || e.error === 'OverLimitError'
+      )
+      if (limitError != null) {
+        const side = request.quoteFor === 'to' ? 'to' : 'from'
+        const limit =
+          side === 'to'
+            ? limitError.destinationAmountLimit
+            : limitError.sourceAmountLimit
+        if (limit != null) {
+          if (limitError.error === 'UnderLimitError') {
+            throw new SwapBelowLimitError(swapInfo, limit, side)
+          }
+          throw new SwapAboveLimitError(swapInfo, limit, side)
+        }
       }
       // Unsupported asset or pair/direction (e.g. selling NYM to a UTXO chain).
       throw new SwapCurrencyError(swapInfo, request)

--- a/test/nym.test.ts
+++ b/test/nym.test.ts
@@ -118,16 +118,29 @@ const makeFakeWallet = (opts: FakeWalletOpts): EdgeCurrencyWallet => {
   } as unknown) as EdgeCurrencyWallet
 }
 
+/** A 400 error body the fake `fetchCors` returns for the /quote endpoint. */
+type QuoteError = Record<string, unknown> | null
+
 /**
  * Canned quote + order responses from NYM's partner API. The quote echoes the
  * requested `sourceAmount` back, as the live API does, so a max swap's second
- * (post-`getMaxSpendable`) quote reports the trimmed amount.
+ * (post-`getMaxSpendable`) quote reports the trimmed amount. Pass `quoteError`
+ * to make the /quote endpoint fail with that 400 body, mirroring NYM rejecting
+ * an out-of-limit amount before it will quote.
  */
-const makeFakeIo = (): { fetchCors: Function } => {
+const makeFakeIo = (quoteError: QuoteError = null): { fetchCors: Function } => {
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString()
   return {
     fetchCors: async (uri: string, opts: { body: string }) => {
       const sent = JSON.parse(opts.body)
+      if (uri.endsWith('/quote') && quoteError != null) {
+        return {
+          ok: false,
+          status: 400,
+          json: async () => quoteError,
+          text: async () => JSON.stringify(quoteError)
+        }
+      }
       const body = uri.endsWith('/quote')
         ? {
             quoteId: 'quote-1',
@@ -158,9 +171,9 @@ const makeFakeIo = (): { fetchCors: Function } => {
   }
 }
 
-const makePlugin = (): EdgeSwapPlugin =>
+const makePlugin = (quoteError: QuoteError = null): EdgeSwapPlugin =>
   makeNymPlugin(({
-    io: makeFakeIo(),
+    io: makeFakeIo(quoteError),
     initOptions: { apiKey: 'test-key' },
     log: { warn() {} }
   } as unknown) as EdgeCorePluginOptions)
@@ -274,6 +287,96 @@ describe('nym', function () {
         () => assert.fail('expected SwapCurrencyError'),
         (error: unknown) =>
           assert.equal((error as Error).name, 'SwapCurrencyError')
+      )
+  })
+
+  it('maps a below-minimum max swap to SwapBelowLimitError, not SwapCurrencyError', async function () {
+    // A native-EVM wallet whose ENTIRE balance is below NYM's minimum: the
+    // whole-balance max probe gets NYM's 400 `UnderLimitError`. Mapped to the
+    // ranked `SwapBelowLimitError` it wins error ranking and tells the user the
+    // real reason; left as `SwapCurrencyError` it loses to an unrelated plugin
+    // and surfaces the misleading "No enabled exchanges support ETH to NYM".
+    const fromWallet = makeFakeWallet({
+      pluginId: 'ethereum',
+      currencyCode: 'ETH',
+      address: ETH_ADDRESS,
+      evmChainId: 1,
+      balanceMap: new Map([[null, '3500000000000000']])
+    })
+
+    const request: EdgeSwapRequest = {
+      fromWallet,
+      fromTokenId: null,
+      toWallet: makeNymWallet(),
+      toTokenId: null,
+      nativeAmount: '0',
+      quoteFor: 'max'
+    }
+
+    const quoteError = {
+      errors: [
+        {
+          error: 'UnderLimitError',
+          sourceAmountLimit: '5000000000000000',
+          destinationAmountLimit: '511491944'
+        }
+      ]
+    }
+
+    await makePlugin(quoteError)
+      .fetchSwapQuote(request, undefined, { infoPayload: {} })
+      .then(
+        () => assert.fail('expected SwapBelowLimitError'),
+        (error: unknown) => {
+          assert.equal((error as Error).name, 'SwapBelowLimitError')
+          // The source-side limit, in native units, comes straight from NYM.
+          assert.equal(
+            (error as { nativeMin?: string }).nativeMin,
+            '5000000000000000'
+          )
+        }
+      )
+  })
+
+  it('maps an above-maximum swap to SwapAboveLimitError', async function () {
+    const fromWallet = makeFakeWallet({
+      pluginId: 'ethereum',
+      currencyCode: 'USDT',
+      address: ETH_ADDRESS,
+      evmChainId: 1,
+      balanceMap: new Map([[USDT_TOKEN_ID, '999999000000']])
+    })
+
+    const request: EdgeSwapRequest = {
+      fromWallet,
+      fromTokenId: USDT_TOKEN_ID,
+      toWallet: makeNymWallet(),
+      toTokenId: null,
+      nativeAmount: '999999000000',
+      quoteFor: 'from'
+    }
+
+    const quoteError = {
+      errors: [
+        {
+          error: 'OverLimitError',
+          sourceAmountLimit: '50000000000',
+          destinationAmountLimit: '2722222222222'
+        }
+      ]
+    }
+
+    await makePlugin(quoteError)
+      .fetchSwapQuote(request, undefined, { infoPayload: {} })
+      .then(
+        () => assert.fail('expected SwapAboveLimitError'),
+        (error: unknown) => {
+          assert.equal((error as Error).name, 'SwapAboveLimitError')
+          assert.equal(
+            (error as { nativeMax?: string }).nativeMax,
+            '50000000000'
+          )
+        }
       )
   })
 })

--- a/test/nym.test.ts
+++ b/test/nym.test.ts
@@ -1,0 +1,279 @@
+import { sub } from 'biggystring'
+import { assert } from 'chai'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyWallet,
+  EdgeSpendInfo,
+  EdgeSwapPlugin,
+  EdgeSwapRequest,
+  EdgeTransaction
+} from 'edge-core-js/types'
+import { describe, it } from 'mocha'
+
+import { makeNymPlugin } from '../src/swap/central/nym'
+
+// Checksummed EVM address. Edge's Ethereum engine stores this exact string as
+// `walletLocalData.publicKey` AND hands it back from `getFreshAddress`, so the
+// swap plugin's refund address and the engine's own public key are identical.
+const ETH_ADDRESS = '0x9A5c4A9F9E6f3fC7f8E1B8B0C9d5e6A7B8C9d0E1'
+const NYM_ADDRESS = 'n1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu'
+const USDT_TOKEN_ID = 'dac17f958d2ee523a2206206994597c13d831ec7'
+const USDT_BALANCE = '14009000'
+// NYM's own ERC-20, which NYM lists on `chainNetwork: 'ethereum'`.
+const NYM_TOKEN_ID = '525a8f6f3ba4752868cde25164382bfbae3990e1'
+const ETH_BALANCE = '1000000000000000000'
+// What the Ethereum engine's native branch holds back for the network fee.
+const ETH_FEE = '196600000000000'
+const ETH_MAX_SPENDABLE = '999803400000000000'
+
+/**
+ * Mirrors the `SpendToSelfError` guard in edge-currency-accountbased's
+ * `makeSpendCheck`, which every engine call runs before pricing a spend.
+ */
+class SpendToSelfError extends Error {
+  name = 'SpendToSelfError'
+  constructor() {
+    super('Spend to self')
+  }
+}
+
+interface FakeWalletOpts {
+  pluginId: string
+  currencyCode: string
+  address: string
+  evmChainId?: number
+  balanceMap?: Map<string | null, string>
+  /** Records every spend the plugin asks the engine to price. */
+  spendLog?: EdgeSpendInfo[]
+}
+
+const makeFakeWallet = (opts: FakeWalletOpts): EdgeCurrencyWallet => {
+  const {
+    address,
+    balanceMap = new Map(),
+    currencyCode,
+    evmChainId,
+    pluginId,
+    spendLog = []
+  } = opts
+
+  const checkSpend = (spendInfo: EdgeSpendInfo): void => {
+    spendLog.push(spendInfo)
+    const { skipChecks = false } = spendInfo
+    for (const spendTarget of spendInfo.spendTargets) {
+      if (!skipChecks && spendTarget.publicAddress === address) {
+        throw new SpendToSelfError()
+      }
+    }
+  }
+
+  const currencyInfo = {
+    pluginId,
+    currencyCode,
+    evmChainId,
+    denominations: [{ name: currencyCode, multiplier: '1000000000000000000' }]
+  }
+
+  return ({
+    id: `${pluginId}-wallet`,
+    balanceMap,
+    currencyInfo,
+    currencyConfig: {
+      // `SwapCurrencyError` reads the pluginId through here.
+      currencyInfo,
+      allTokens: {
+        [USDT_TOKEN_ID]: {
+          currencyCode: 'USDT',
+          denominations: [{ name: 'USDT', multiplier: '1000000' }],
+          networkLocation: { contractAddress: `0x${USDT_TOKEN_ID}` }
+        },
+        [NYM_TOKEN_ID]: {
+          currencyCode: 'NYM',
+          denominations: [{ name: 'NYM', multiplier: '1000000' }],
+          networkLocation: { contractAddress: `0x${NYM_TOKEN_ID}` }
+        }
+      }
+    },
+    async getAddresses() {
+      return [{ addressType: 'publicAddress', publicAddress: address }]
+    },
+    async getMaxSpendable(spendInfo: EdgeSpendInfo) {
+      checkSpend(spendInfo)
+      const balance = balanceMap.get(spendInfo.tokenId) ?? '0'
+      // Matches the Ethereum engine: the token branch spends the whole token
+      // balance (the fee comes out of the parent currency), while the native
+      // branch holds back the network fee.
+      return spendInfo.tokenId == null ? sub(balance, ETH_FEE) : balance
+    },
+    async makeSpend(spendInfo: EdgeSpendInfo): Promise<EdgeTransaction> {
+      checkSpend(spendInfo)
+      return ({
+        networkFee: '0',
+        parentNetworkFee: '196600000000000',
+        savedAction: spendInfo.savedAction,
+        assetAction: spendInfo.assetAction,
+        tokenId: spendInfo.tokenId
+      } as unknown) as EdgeTransaction
+    }
+  } as unknown) as EdgeCurrencyWallet
+}
+
+/**
+ * Canned quote + order responses from NYM's partner API. The quote echoes the
+ * requested `sourceAmount` back, as the live API does, so a max swap's second
+ * (post-`getMaxSpendable`) quote reports the trimmed amount.
+ */
+const makeFakeIo = (): { fetchCors: Function } => {
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString()
+  return {
+    fetchCors: async (uri: string, opts: { body: string }) => {
+      const sent = JSON.parse(opts.body)
+      const body = uri.endsWith('/quote')
+        ? {
+            quoteId: 'quote-1',
+            sourceAmount: sent.sourceAmount,
+            destinationAmount: '762710000',
+            rate: '54.4',
+            expiresAt,
+            // Wide enough to hold both a token balance and a whole-ETH
+            // balance, so neither max case trips the limit checks.
+            minSourceAmount: '1000000',
+            maxSourceAmount: '10000000000000000000',
+            minDestinationAmount: '1000000',
+            maxDestinationAmount: '100000000000'
+          }
+        : {
+            orderId: 'order-1',
+            status: 'waiting',
+            payinAddress: '0x1111111111111111111111111111111111111111',
+            expiresAt
+          }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+        text: async () => JSON.stringify(body)
+      }
+    }
+  }
+}
+
+const makePlugin = (): EdgeSwapPlugin =>
+  makeNymPlugin(({
+    io: makeFakeIo(),
+    initOptions: { apiKey: 'test-key' },
+    log: { warn() {} }
+  } as unknown) as EdgeCorePluginOptions)
+
+const makeNymWallet = (): EdgeCurrencyWallet =>
+  makeFakeWallet({
+    pluginId: 'nym',
+    currencyCode: 'NYM',
+    address: NYM_ADDRESS
+  })
+
+describe('nym', function () {
+  it('quotes a max swap from an EVM token without spending to self', async function () {
+    const spendLog: EdgeSpendInfo[] = []
+    const fromWallet = makeFakeWallet({
+      pluginId: 'ethereum',
+      currencyCode: 'ETH',
+      address: ETH_ADDRESS,
+      evmChainId: 1,
+      balanceMap: new Map([[USDT_TOKEN_ID, USDT_BALANCE]]),
+      spendLog
+    })
+
+    const request: EdgeSwapRequest = {
+      fromWallet,
+      fromTokenId: USDT_TOKEN_ID,
+      toWallet: makeNymWallet(),
+      toTokenId: null,
+      nativeAmount: '0',
+      quoteFor: 'max'
+    }
+
+    const quote = await makePlugin().fetchSwapQuote(request, undefined, {
+      infoPayload: {}
+    })
+
+    assert.equal(quote.fromNativeAmount, USDT_BALANCE)
+    // The fee-estimation probe targets the user's own address, so it must opt
+    // out of the engine's spend checks; the real order must not.
+    const [probeSpend, orderSpend] = spendLog
+    assert.equal(probeSpend.skipChecks, true)
+    assert.equal(probeSpend.spendTargets[0].publicAddress, ETH_ADDRESS)
+    assert.notEqual(orderSpend.skipChecks, true)
+    assert.notEqual(orderSpend.spendTargets[0].publicAddress, ETH_ADDRESS)
+  })
+
+  it('quotes a max swap from a native EVM asset without spending to self', async function () {
+    // The engine's self-spend guard compares the spend target against its own
+    // public key, which on EVM chains is the address itself, so the probe trips
+    // it for a native balance exactly as it does for a token. The Ethereum
+    // engine runs that check in BOTH `getMaxSpendable` branches.
+    const spendLog: EdgeSpendInfo[] = []
+    const fromWallet = makeFakeWallet({
+      pluginId: 'ethereum',
+      currencyCode: 'ETH',
+      address: ETH_ADDRESS,
+      evmChainId: 1,
+      balanceMap: new Map([[null, ETH_BALANCE]]),
+      spendLog
+    })
+
+    const request: EdgeSwapRequest = {
+      fromWallet,
+      fromTokenId: null,
+      toWallet: makeNymWallet(),
+      toTokenId: null,
+      nativeAmount: '0',
+      quoteFor: 'max'
+    }
+
+    const quote = await makePlugin().fetchSwapQuote(request, undefined, {
+      infoPayload: {}
+    })
+
+    // The max quote is the whole balance less the held-back network fee.
+    assert.equal(quote.fromNativeAmount, ETH_MAX_SPENDABLE)
+    const [probeSpend, orderSpend] = spendLog
+    assert.equal(probeSpend.tokenId, null)
+    assert.equal(probeSpend.skipChecks, true)
+    assert.equal(probeSpend.spendTargets[0].publicAddress, ETH_ADDRESS)
+    assert.notEqual(orderSpend.skipChecks, true)
+    assert.notEqual(orderSpend.spendTargets[0].publicAddress, ETH_ADDRESS)
+  })
+
+  it('rejects an EVM-to-EVM pair, which NYM does not route', async function () {
+    // NYM provides its own liquidity, so its API requires native NYM (the Nyx
+    // chain) on one side: `ETH -> NYM (ERC-20)` comes back as
+    // "Unsupported swap pair: one side must be NYM" even though both assets are
+    // listed. The plugin gates the same rule locally, which also covers the
+    // same-wallet case, where the from and to wallets are one EVM wallet.
+    const wallet = makeFakeWallet({
+      pluginId: 'ethereum',
+      currencyCode: 'ETH',
+      address: ETH_ADDRESS,
+      evmChainId: 1,
+      balanceMap: new Map([[null, ETH_BALANCE]])
+    })
+
+    const request: EdgeSwapRequest = {
+      fromWallet: wallet,
+      fromTokenId: null,
+      toWallet: wallet,
+      toTokenId: NYM_TOKEN_ID,
+      nativeAmount: '0',
+      quoteFor: 'max'
+    }
+
+    await makePlugin()
+      .fetchSwapQuote(request, undefined, { infoPayload: {} })
+      .then(
+        () => assert.fail('expected SwapCurrencyError'),
+        (error: unknown) =>
+          assert.equal((error as Error).name, 'SwapCurrencyError')
+      )
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Fixes [Swap (NYM) - Max amount reports unsupported route (for tokens)](https://app.asana.com/0/1215088146871429/1216815078906704).

Tapping MAX on the Exchange scene with an Ethereum wallet as the source (USDT on Ethereum to native NYM) failed with "No enabled exchanges support USDT to NYM", while typing the same amount manually quoted fine through NYM. The follow-up verification confirmed the same "no enabled exchanges" message reproduces from a native ETH wallet, not just tokens. Two distinct defects both surface as that misleading message because edge-core-js ranks the real error below an unrelated plugin's `SwapCurrencyError`.

**Root cause 1 (max-swap spend to self).** NYM's max-swap path builds a fee-estimation probe (`fetchProbeOrder`) so a max request does not create and abandon a live NYM order. `getMaxSwappable` hands that probe's `spendInfo` to `getMaxSpendable`, and the probe's only available from-chain address is the user's own refund address. `makeSpendCheck` in edge-currency-accountbased throws `SpendToSelfError` whenever a spend target equals `walletLocalData.publicKey`, and on every EVM chain that public key IS the address, so the probe threw before it could price anything. `SpendToSelfError` is not one of the swap error types edge-core-js ranks, so `pickBestError` preferred the `SwapCurrencyError` raised by the plugins that genuinely do not support NYM. This affects both tokens and native ETH (the public-key-is-address property is the same); native NYM as the source was unaffected because Cosmos stores a base16 pubkey while its addresses are bech32, so the self-check never matched. That matches the reporter's note that "NYM itself is able to max exchange and works".

**Fix 1.** Mark the probe spend `skipChecks`. It is never broadcast and exists only so `getMaxSpendable` can price the network fee before the real order (and its payin address) exists. The real order path keeps every check.

**Root cause 2 (out-of-limit amount).** NYM rejects an amount outside an asset's min/max with an HTTP 400 (`UnderLimitError` / `OverLimitError`) BEFORE it returns a quote, so the plugin never reaches the min/max check that a successful quote runs. `handleErrorResponse` mapped every error-array body to `SwapCurrencyError`, which again loses error ranking to other plugins. In the app this is what a native ETH wallet holding less than NYM's 0.005 ETH minimum hits on a max swap: the whole-balance probe gets `UnderLimitError`, mismapped to `SwapCurrencyError`, and the user sees "No enabled exchanges support ETH to NYM" instead of a below-limit message.

**Fix 2.** Map NYM's `UnderLimitError` / `OverLimitError` to the ranked `SwapBelowLimitError` / `SwapAboveLimitError`, carrying NYM's own native-unit boundary and following the request direction (a `to` quote is bounded by the destination amount, everything else by the source amount). These rank above `SwapCurrencyError`, so the correct "below the limit" / "above the limit" message wins.

**Same-wallet vs different-wallet note.** NYM provides its own liquidity, so its API requires native NYM on one side: an EVM-to-EVM pair (the "same EVM wallet on both sides" case) is rejected by NYM itself with "Unsupported swap pair: one side must be NYM", and the plugin gates that locally. A NYM swap is therefore always an EVM source wallet to a separate NYM wallet; the self-spend probe targets the source wallet's own refund address regardless of the destination, which is why the bug did not depend on the destination wallet.

`test/nym.test.ts` covers all of it: fake wallets mirror the engine's `SpendToSelfError` guard, and the tests assert a `quoteFor: 'max'` request quotes the full balance for both an EVM token and a native EVM asset (probe carries `skipChecks`, real order does not), that an EVM-to-EVM pair is rejected, and that `UnderLimitError` / `OverLimitError` map to `SwapBelowLimitError` / `SwapAboveLimitError` with NYM's limit. The self-spend and limit tests fail on the pre-fix code.

**Testing.** Verified in-app on the iOS simulator (`edge-funds`) with this branch's plugin bundle installed, default provider set enabled:
- USDT (Ethereum, 32.468) in My Ether 4 to native NYM, MAX: now resolves to a full NYM quote (1,901.66 NYM, "Slide to Confirm") instead of the exchange error.
- Native ETH (My Ether 4, 0.0035 ETH, below NYM's 0.005 min) to native NYM, MAX: now shows "Amount is below the min limit of 0.005 ETH" instead of "No enabled exchanges support ETH to NYM".

`npm run verify` (prepare + tsc + eslint + mocha) passes. Screenshots in the comment below.
