### PR TITLE
Fix Maya RUNE swaps: deposit misrouting and base-asset pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fixed: Maya swaps spending RUNE now send to Maya's inbound address instead of depositing into THORChain's own state machine, which misrouted the swap (THORChain read Maya's `=:d:` DASH memo as an unparseable DOGE swap and the deposit failed).
+- fixed: Maya quotes now price RUNE from Maya's real THOR.RUNE pool instead of treating it as Maya's own base asset, which skewed destination-amount quotes by the RUNE/CACAO ratio.
 
 ## 2.52.1 (2026-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Maya swaps spending RUNE now send to Maya's inbound address instead of depositing into THORChain's own state machine, which misrouted the swap (THORChain read Maya's `=:d:` DASH memo as an unparseable DOGE swap and the deposit failed).
+
 ## 2.52.1 (2026-07-24)
 
 - fixed: (NYM) Max swaps from EVM wallets no longer fail with "No enabled exchanges support". The fee-estimation probe targets the user's own address, which the engine rejected as a spend to self.

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -76,6 +76,27 @@ export const getNodeLimitUnits = (
   wallet.currencyInfo.pluginId === 'mayachain'
     ? getTokenMultiplier(wallet, tokenId)
     : THOR_LIMIT_UNITS
+
+/** Each provider's own protocol chain, by swap pluginId */
+const PROVIDER_NATIVE_PLUGIN_ID: { [swapPluginId: string]: string } = {
+  thorchain: 'thorchainrune',
+  mayaprotocol: 'mayachain'
+}
+
+// The MsgDeposit path only applies when spending an asset native to the swap
+// provider's own protocol chain: RUNE (or THOR-chain tokens) via THORChain,
+// CACAO (or MAYA-chain tokens) via Maya. An asset from the *other* protocol's
+// chain — e.g. RUNE swapped through Maya — is just another external asset to
+// that provider and must be sent to the quote's inbound address. Depositing it
+// instead hands the memo to the wrong protocol: THORChain executes Maya's
+// `=:d:<dashAddr>` as a DOGE swap and fails to parse the DASH address.
+export const isProviderNativeDeposit = (
+  swapInfo: EdgeSwapInfo,
+  fromWallet: EdgeCurrencyWallet
+): boolean =>
+  PROVIDER_NATIVE_PLUGIN_ID[swapInfo.pluginId] ===
+  fromWallet.currencyInfo.pluginId
+
 const NATIVE_IN_GWEI = '1000000000'
 const STREAMING_INTERVAL_DEFAULT = 10
 const STREAMING_QUANTITY_DEFAULT = 10
@@ -778,10 +799,7 @@ export function makeThorchainBasedPlugin(
         memo
       })
       memo = memo.replace(/^0x/, '')
-    } else if (
-      fromWallet.currencyInfo.pluginId === 'thorchainrune' ||
-      fromWallet.currencyInfo.pluginId === 'mayachain'
-    ) {
+    } else if (isProviderNativeDeposit(swapInfo, fromWallet)) {
       const chainPrefix =
         fromWallet.currencyInfo.pluginId === 'thorchainrune' ? 'THOR' : 'MAYA'
       const makeTxParams: MakeTxParams = {
@@ -893,7 +911,8 @@ export function makeThorchainBasedPlugin(
       // Set publicAddress for spendTargets
       publicAddress = thorAddress
     } else {
-      // For UTXO chains, we send the memo as text which gets
+      // For UTXO chains and bank sends to the provider's inbound address
+      // (e.g. RUNE swapped through Maya), we send the memo as text which gets
       // encoded by the plugins
       memoType = 'text'
 
@@ -1016,12 +1035,12 @@ export function makeThorchainBasedPlugin(
       let swapOrder
       if (
         quoteFor === 'max' &&
-        (fromWallet.currencyInfo.pluginId === 'thorchainrune' ||
-          fromWallet.currencyInfo.pluginId === 'mayachain') &&
+        isProviderNativeDeposit(swapInfo, fromWallet) &&
         request.fromTokenId == null
       ) {
         // fetchSwapQuoteInner has unique logic to handle 'max' quotes but
-        // only when sending RUNE or CACAO
+        // only for the provider's own deposit path (RUNE via THORChain,
+        // CACAO via Maya)
         swapOrder = await fetchSwapQuoteInner(request, true)
       } else {
         const newRequest = await getMaxSwappable(
@@ -1114,9 +1133,7 @@ const calcSwapFrom = async ({
   // clear the provider's minimum. 10 RUNE works for Thorchain; CACAO is lower
   // value and 10-decimal, so probe with ~1000 CACAO to stay above Maya's min.
   const isNativeDeposit =
-    (fromWallet.currencyInfo.pluginId === 'thorchainrune' ||
-      fromWallet.currencyInfo.pluginId === 'mayachain') &&
-    fromTokenId == null
+    isProviderNativeDeposit(swapInfo, fromWallet) && fromTokenId == null
   const maxSeedAmount =
     fromWallet.currencyInfo.pluginId === 'mayachain'
       ? mul('1000', getTokenMultiplier(fromWallet, fromTokenId))

--- a/src/swap/defi/thorchain/thorchainCommon.ts
+++ b/src/swap/defi/thorchain/thorchainCommon.ts
@@ -1058,8 +1058,17 @@ export function makeThorchainBasedPlugin(
 }
 
 /**
- * Create a fake pool for native base tokens (RUNE/CACAO) that don't have
- * their own pools. Uses BTC pool to derive USD price.
+ * Each provider's own base asset. A provider prices every pool in this asset,
+ * so it never lists a pool for the asset itself.
+ */
+const PROVIDER_BASE_ASSET: { [swapPluginId: string]: string } = {
+  thorchain: 'THOR.RUNE',
+  mayaprotocol: 'MAYA.CACAO'
+}
+
+/**
+ * Create a fake pool for a provider's own base asset, which has no pool of its
+ * own. Its price in itself is 1; the BTC pool supplies the USD price.
  */
 const createNativePool = (
   request: EdgeSwapRequestPlugin,
@@ -1079,29 +1088,30 @@ const createNativePool = (
   }
 }
 
-const getPool = (
+export const getPool = (
   request: EdgeSwapRequestPlugin,
   swapInfo: EdgeSwapInfo,
   mainnetCode: string,
   tokenCode: string,
   pools: Pool[]
 ): Pool => {
-  // Handle native base tokens that don't have their own pools
-  if (mainnetCode === 'THOR' && tokenCode === 'RUNE') {
-    return createNativePool(request, swapInfo, 'THOR.RUNE', pools)
-  }
-  if (mainnetCode === 'MAYA' && tokenCode === 'CACAO') {
-    return createNativePool(request, swapInfo, 'MAYA.CACAO', pools)
-  }
+  const wantedAsset = `${mainnetCode}.${tokenCode}`
 
   const pool = pools.find(pool => {
     const [asset] = pool.asset.split('-')
-    return asset === `${mainnetCode}.${tokenCode}`
+    return asset === wantedAsset
   })
-  if (pool == null) {
-    throw new SwapCurrencyError(swapInfo, request)
+  if (pool != null) return pool
+
+  // Only the provider's OWN base asset is missing a pool. Another protocol's
+  // base asset is an ordinary bridged asset here, with a real pool: Maya lists
+  // THOR.RUNE, and pricing it as a base asset (1 CACAO per RUNE instead of the
+  // pool's rate) skewed 'to' quotes by the whole RUNE/CACAO ratio.
+  if (PROVIDER_BASE_ASSET[swapInfo.pluginId] === wantedAsset) {
+    return createNativePool(request, swapInfo, wantedAsset, pools)
   }
-  return pool
+
+  throw new SwapCurrencyError(swapInfo, request)
 }
 
 const calcSwapFrom = async ({

--- a/test/mayaprotocol.test.ts
+++ b/test/mayaprotocol.test.ts
@@ -6,7 +6,10 @@ import {
 } from 'edge-core-js/types'
 import { describe, it } from 'mocha'
 
-import { getNodeLimitUnits } from '../src/swap/defi/thorchain/thorchainCommon'
+import {
+  getNodeLimitUnits,
+  isProviderNativeDeposit
+} from '../src/swap/defi/thorchain/thorchainCommon'
 
 const mayaSwapInfo: EdgeSwapInfo = {
   pluginId: 'mayaprotocol',
@@ -66,6 +69,7 @@ const dashWallet = makeFakeWallet('dash', 'DASH', '100000000')
 const mayachainWallet = makeFakeWallet('mayachain', 'CACAO', '10000000000', [
   { tokenId: 'mayatokenid', currencyCode: 'MAYA', multiplier: '10000' }
 ])
+const thorchainruneWallet = makeFakeWallet('thorchainrune', 'RUNE', '100000000')
 
 describe(`getNodeLimitUnits`, function () {
   // Mayanode normalizes bridged assets to 1e8 no matter their own precision,
@@ -111,5 +115,39 @@ describe(`getNodeLimitUnits`, function () {
       getNodeLimitUnits(thorSwapInfo, mayachainWallet, null),
       '100000000'
     )
+  })
+})
+
+describe(`isProviderNativeDeposit`, function () {
+  // The MsgDeposit path only applies on the provider's own protocol chain.
+  it('thorchain deposits RUNE', function () {
+    assert.equal(
+      isProviderNativeDeposit(thorSwapInfo, thorchainruneWallet),
+      true
+    )
+  })
+
+  it('maya deposits CACAO', function () {
+    assert.equal(isProviderNativeDeposit(mayaSwapInfo, mayachainWallet), true)
+  })
+
+  // RUNE is an external asset to Maya. It must be sent to Maya's inbound
+  // address like any other chain — depositing it hands Maya's memo to
+  // THORChain, which misparses it (e.g. `=:d:<dashAddr>` becomes a DOGE swap
+  // with an unparseable address).
+  it('maya must NOT deposit RUNE', function () {
+    assert.equal(
+      isProviderNativeDeposit(mayaSwapInfo, thorchainruneWallet),
+      false
+    )
+  })
+
+  it('thorchain must NOT deposit CACAO', function () {
+    assert.equal(isProviderNativeDeposit(thorSwapInfo, mayachainWallet), false)
+  })
+
+  it('external chains never deposit', function () {
+    assert.equal(isProviderNativeDeposit(mayaSwapInfo, dashWallet), false)
+    assert.equal(isProviderNativeDeposit(thorSwapInfo, ethWallet), false)
   })
 })

--- a/test/mayaprotocol.test.ts
+++ b/test/mayaprotocol.test.ts
@@ -8,8 +8,10 @@ import { describe, it } from 'mocha'
 
 import {
   getNodeLimitUnits,
+  getPool,
   isProviderNativeDeposit
 } from '../src/swap/defi/thorchain/thorchainCommon'
+import { EdgeSwapRequestPlugin } from '../src/swap/types'
 
 const mayaSwapInfo: EdgeSwapInfo = {
   pluginId: 'mayaprotocol',
@@ -149,5 +151,99 @@ describe(`isProviderNativeDeposit`, function () {
   it('external chains never deposit', function () {
     assert.equal(isProviderNativeDeposit(mayaSwapInfo, dashWallet), false)
     assert.equal(isProviderNativeDeposit(thorSwapInfo, ethWallet), false)
+  })
+})
+
+// Only the fields SwapCurrencyError reads:
+const fakeRequest = ({
+  fromWallet: {
+    currencyConfig: { currencyInfo: { pluginId: 'thorchainrune' } }
+  },
+  toWallet: { currencyConfig: { currencyInfo: { pluginId: 'dash' } } },
+  fromTokenId: null,
+  toTokenId: null
+} as unknown) as EdgeSwapRequestPlugin
+
+// Real prices from midgard.mayachain.info. Maya lists a THOR.RUNE pool but no
+// MAYA.CACAO pool, since it prices everything in CACAO.
+const mayaPools = [
+  { asset: 'BTC.BTC', assetPrice: '545667.63', assetPriceUSD: '65051.66' },
+  {
+    asset: 'THOR.RUNE',
+    assetPrice: '3.578525528664948',
+    assetPriceUSD: '0.42'
+  },
+  { asset: 'DASH.DASH', assetPrice: '276.94', assetPriceUSD: '33.01' },
+  { asset: 'MAYA.MAYA', assetPrice: '1234.5', assetPriceUSD: '147.2' }
+]
+
+// Real shape from THORChain's midgard: no THOR.RUNE pool (everything is priced
+// in RUNE), but THOR-native tokens do get their own pools.
+const thorPools = [
+  { asset: 'BTC.BTC', assetPrice: '152503.1', assetPriceUSD: '65051.66' },
+  { asset: 'THOR.TCY', assetPrice: '0.0189', assetPriceUSD: '0.008' },
+  {
+    asset: 'ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48',
+    assetPrice: '2.34',
+    assetPriceUSD: '1.00'
+  }
+]
+
+describe(`getPool`, function () {
+  // Maya treats RUNE as an ordinary bridged asset with a real pool. Pricing it
+  // as a base asset (assetPrice '1') put the 'to' quote out by the whole
+  // RUNE/CACAO ratio — ~3.58x here.
+  it('maya prices RUNE from its real pool, not as a base asset', function () {
+    const pool = getPool(fakeRequest, mayaSwapInfo, 'THOR', 'RUNE', mayaPools)
+    assert.equal(pool.asset, 'THOR.RUNE')
+    assert.equal(pool.assetPrice, '3.578525528664948')
+  })
+
+  // THORChain lists no pool for its own base asset, so it still gets a
+  // synthetic one priced at 1.
+  it('thorchain synthesizes a RUNE pool priced at 1', function () {
+    const pool = getPool(fakeRequest, thorSwapInfo, 'THOR', 'RUNE', thorPools)
+    assert.equal(pool.asset, 'THOR.RUNE')
+    assert.equal(pool.assetPrice, '1')
+  })
+
+  it('maya synthesizes a CACAO pool priced at 1', function () {
+    const pool = getPool(fakeRequest, mayaSwapInfo, 'MAYA', 'CACAO', mayaPools)
+    assert.equal(pool.asset, 'MAYA.CACAO')
+    assert.equal(pool.assetPrice, '1')
+  })
+
+  it('uses the real pool for a provider-native token', function () {
+    const thorTcy = getPool(fakeRequest, thorSwapInfo, 'THOR', 'TCY', thorPools)
+    assert.equal(thorTcy.assetPrice, '0.0189')
+    const mayaMaya = getPool(
+      fakeRequest,
+      mayaSwapInfo,
+      'MAYA',
+      'MAYA',
+      mayaPools
+    )
+    assert.equal(mayaMaya.assetPrice, '1234.5')
+  })
+
+  it('matches a token pool despite its contract-address suffix', function () {
+    const pool = getPool(fakeRequest, thorSwapInfo, 'ETH', 'USDC', thorPools)
+    assert.equal(pool.assetPrice, '2.34')
+  })
+
+  it('throws for an asset with no pool', function () {
+    assert.throws(
+      () => getPool(fakeRequest, mayaSwapInfo, 'LTC', 'LTC', mayaPools),
+      /does not support/
+    )
+  })
+
+  // CACAO is not a base asset to THORChain, so it must not be synthesized
+  // there — it would price CACAO at 1 RUNE.
+  it('does not synthesize another protocol base asset', function () {
+    assert.throws(
+      () => getPool(fakeRequest, thorSwapInfo, 'MAYA', 'CACAO', thorPools),
+      /does not support/
+    )
   })
 })


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana: Swap (Maya) - RUNE-DASH routes to Thorchain and Fails](https://app.asana.com/1/9976422036640/project/1213880789473005/task/1216772228906406)

Two bugs of the same shape: `thorchainCommon` is shared by the `thorchain` and `mayaprotocol` plugins, and in both places it asked "what chain is this asset on?" when it needed to ask "is this asset native to the provider that gave me this quote?" Those questions agree except on RUNE-via-Maya.

## 1. Swaps from RUNE were deposited into THORChain instead of sent to Maya

The `MsgDeposit` path keyed off the from-wallet's chain:

```ts
} else if (
  fromWallet.currencyInfo.pluginId === 'thorchainrune' ||
  fromWallet.currencyInfo.pluginId === 'mayachain'
) {
```

So a Maya-quoted swap spending RUNE built a native THORChain deposit and discarded the Mayanode quote's `inbound_address`. THORChain then executed Maya's memo: `=:d:<dashAddr>` parses `d` as DOGE on THORChain, the DASH address fails to parse, and the message reverts with code 99 (the failing transaction is linked from the Asana ticket). No funds were lost; a failed `MsgDeposit` is atomic, so only the 0.02 RUNE fee was burned and no refund is pending.

RUNE is an external asset to Maya, so it has to be sent to Maya's inbound address like any other chain. This gates the deposit path on the provider's own protocol chain:

```ts
const PROVIDER_NATIVE_PLUGIN_ID = {
  thorchain: 'thorchainrune',
  mayaprotocol: 'mayachain'
}
```

RUNE deposits only for `thorchain`, CACAO deposits only for `mayaprotocol`, and anything else falls through to the existing send-to-inbound-address spend (text memo, `publicAddress` from the quote). The max-quote shortcut in `fetchSwapQuote` and the probe seed in `calcSwapFrom` use the same predicate, so max quotes from RUNE through Maya now go through `getMaxSwappable` like any other external asset. An unrecognized provider fails on the existing `Invalid publicAddress` guard instead of misrouting.

The memo itself was never wrong — only the envelope. Mayanode returns `inbound_address: thor12qm45uyzg5kk3aw3s5jzew7gkelvg7pdsw9kzg` for a THOR.RUNE source, a plain account from THORChain's perspective, so a `MsgSend` there moves the coins without THORChain parsing the memo, and Maya's observers pick it up.

Scope: every Maya swap spending RUNE was affected, and had been since before the mappings moved to `src/mappings`. Maya-exclusive destinations (DASH, ZEC, ARB — all `null` in the thorchain mapping) failed loudly. Shared destinations (BTC, ETH) were quieter and worse: they executed on THORChain with a limit-0 memo whenever Maya won the quote.

## 2. Maya priced RUNE as if it were Maya's own base asset

`getPool` special-cased `THOR.RUNE` and `MAYA.CACAO` into a synthetic pool priced at 1, without checking which provider was asking. That is only correct for a provider's *own* base asset: a provider prices every pool in its base asset, so it lists no pool for the asset itself. Confirmed against both live Midgards:

| provider | THOR.RUNE pool | MAYA.CACAO pool | own tokens |
|---|---|---|---|
| thorchain | absent | absent | THOR.TCY, THOR.RUJI present |
| mayaprotocol | **present, 3.578 CACAO** | absent | MAYA.MAYA present |

So Maya was pricing RUNE at 1 CACAO instead of 3.578 — off by the whole RUNE/CACAO ratio. `assetPrice` feeds the initial estimate in `calcSwapTo` (the direction where the user enters the destination amount), and the `feeRatio` correction afterward recovers most of it — tracing 1 DASH, the bad estimate probes 276.9 RUNE instead of 77.4 and corrects back to 77.3 — so this bit hardest where the inflated probe hit pool depth or a min/max boundary rather than producing visibly wrong quotes.

`getPool` now looks the pool up first and synthesizes only for the asking provider's own base asset, keyed by the same provider-map pattern as fix 1. This also removes the hardcoded asset pair.

### Testing

- `test/mayaprotocol.test.ts`: 5 tests for the deposit predicate (both directions, including `maya must NOT deposit RUNE`) and 7 for `getPool`, using real pool shapes from both Midgards.
- Each fix's key test was confirmed to fail against the old behavior before being kept.
- `npm run test` (51 passing), `tsc`, and eslint clean.
- Neither fix has been run against a live swap. Worth a QA pass on Maya RUNE→DASH, in both the from- and to-amount directions, before the 50.1 build.

The other half of the ticket — the failed swap still showing in the transaction list — is fixed separately in edge-currency-accountbased.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216838957023378

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared swap execution and quote math for Maya/THORChain; misclassification could still misroute funds or skew quotes, though scope is narrow and covered by new unit tests.
> 
> **Overview**
> Shared **THORChain/Maya** logic in `thorchainCommon` now keys off **which swap plugin quoted the swap**, not only which wallet chain the source asset lives on.
> 
> **Deposit path:** `isProviderNativeDeposit` gates the native `MsgDeposit` flow to each provider’s own chain (RUNE on THORChain, CACAO on Maya). Maya swaps that spend RUNE no longer use that path—they send to the quote **inbound address** with a text memo like other external assets, avoiding THORChain mis-parsing Maya memos (e.g. DASH routes failing as DOGE). Max-quote and `calcSwapFrom` seed logic use the same predicate.
> 
> **Quoting:** `getPool` only synthesizes a base-asset pool (price `1`) for the **active provider’s** base asset. On Maya, **THOR.RUNE** is taken from Midgard’s real pool instead of being treated like CACAO, fixing skewed destination-amount (`to`) estimates.
> 
> Tests in `test/mayaprotocol.test.ts` cover deposit gating and pool selection; CHANGELOG updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4ba5901909eeffa2e458be2cd0f3740da1ae0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->