### PR TITLE
Treat an empty Swapuz memoFrom as no memo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: (Swapuz) Quotes no longer disappear on chains without text-memo support. Swapuz returns an empty-string `memoFrom` for assets that take no deposit memo, which the plugin turned into a zero-length text memo and every EVM chain rejected.
+
 ## 2.52.2 (2026-07-27)
 
 - fixed: Maya swaps spending RUNE now send to Maya's inbound address instead of depositing into THORChain's own state machine, which misrouted the swap (THORChain read Maya's `=:d:` DASH memo as an unparseable DOGE swap and the deposit failed).

--- a/src/swap/central/swapuz.ts
+++ b/src/swap/central/swapuz.ts
@@ -243,7 +243,7 @@ export function makeSwapuzPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       )
 
       const memos: EdgeMemo[] =
-        memoFrom == null
+        memoFrom == null || memoFrom === ''
           ? []
           : [
               {


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

[Asana task](https://app.asana.com/0/0/1217610250865992/f)

Asana: https://app.asana.com/1/9976422036640/project/1213880789473005/task/1217610250865992

Investigating why Edge stopped sending swap volume to Swapuz around Aug 1.

Swapuz's `POST https://api.swapuz.com/api/home/v1/order` returns `"memoFrom": ""` (an empty string, not `null`) for source assets that take no deposit memo. Verified live today on ETH (mainnet), BNB (BSC), AVAX, USDT (TRX), BTC, XMR, LTC, DOGE and DASH orders; L2 ETH, USDT on Ethereum, USDC on Polygon and SOL still return `null`, and XRP still returns a real numeric memo.

`swapuz.ts` only guarded `memoFrom == null`, so every one of those orders produced a `{ type: 'text', value: '' }` memo on the deposit spend. `memoType()` maps every plugin except ripple, stellar and zano to `text`, and the EVM `memoOptions` (`evmMemoOptions`) only allow `hex`, so `validateMemos` throws inside `makeSpend`, `makeSwapPluginQuote` never returns, and Swapuz silently disappears from the provider list. UTXO chains survive on their legacy `memoType: 'text'` entry, and Monero never calls `validateMemos`, which is why the failure looked partial.

Because the throw happens *after* the order is created, Swapuz sees orders being created that are never funded.

This guards the empty string as well, matching the existing idiom in `changelly.ts` and `nexchange.ts`. Real memos are untouched.

Same `== null`-only pattern still exists in `changehero.ts`, `exolix.ts`, `letsexchange.ts`, `godex.ts`, `sideshift.ts`, `nym.ts` and `template.ts`; none of those partners is currently returning an empty string, so they are left alone here.

**Testing** (iOS sim, `corePlugins.ts` filtered to swapuz only, plugin bundle served live from this branch via `DEBUG_EXCHANGES`):

- Base ETH to XMR with the empty memo forced on: `Exchange Error: No enabled exchanges support ETH to XMR`.
- Same flow with this fix: a Swapuz quote renders (0.0549473 ETH to 0.248 XMR).
- With the force removed and this fix in place, a real swap executed end to end: 0.0549247 ETH (Base) to 0.247 XMR, Swapuz order `mkc38f5cb9b`, deposit tx `0xcd5975d59013d7f5929ace743542a1a6b9f5a5ae6036cc206cd30b9f4394276a`, success scene reached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in Swapuz memo handling with no auth or data-model impact; behavior only affects empty-string memos from the API.
> 
> **Overview**
> Swapuz sometimes returns **`memoFrom` as an empty string** instead of `null` for deposits that do not need a memo. The plugin only skipped memos when `memoFrom == null`, so those quotes built a **zero-length `text` memo** on the deposit spend. **EVM chains reject that** during `validateMemos` / `makeSpend`, so Swapuz quotes failed after the order was created and the provider dropped off the enabled list.
> 
> The memo guard now treats **`memoFrom === ''` the same as missing** (no memos on `spendInfo`), matching the pattern used in other CEX plugins. Non-empty memos are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f2e190877f7d7bf5539e926b51a14c2feeed5ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->