### PR TITLE
Restore and unify `API_REQUIREMENTS.md`

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -32,6 +32,10 @@ Provider docs are wrong about units often enough that a claim needs a live
 response behind it. Decimal-vs-base-unit mistakes are silent whenever the pairs
 used during development happen to return null limits.
 
+`docs/API_REQUIREMENTS.md` asks partners for native units, which is what Edge
+asks for rather than evidence about a particular provider. It does not settle
+the question either way.
+
 ### Use `biggystring`, Not Floats (`biggystring-not-floats`)
 
 Applies to comparison and sorting too, not just arithmetic. `String(smallFloat)`
@@ -186,6 +190,30 @@ A local backoff cap must bound only our own doubling. Truncating a reported
 `retryAfter` fires retries early and burns the provider's budget. A backoff that
 would land past the quote's own expiry should fail as a rate limit immediately
 rather than sleep through the window and then report an expired quote.
+
+### Credentials Go Per Endpoint (`per-endpoint-auth`)
+
+Some provider endpoints reject an authenticated request outright: a public
+catalog route can return 401 for ANY api key header. Flag credentials attached
+globally instead of per endpoint, and check each endpoint's auth expectation
+against a live response rather than the provider's docs.
+
+### Provider Catalogs Need an Expiry (`catalog-cache-expiry`)
+
+A cached list of supported assets or rate types needs a TTL or a
+re-fetch-on-miss path. Flag caching for the lifetime of the plugin justified by
+"these do not change": providers rename, delist and relist assets, and a stale
+catalog refuses a pair the provider now supports.
+
+### Scope a Rate-Type Fallback to What It Compensates For (`rate-type-fallback-scope`)
+
+Attempting a fixed rate and falling back to floating is only correct when the
+provider offers no way to ask which rate types a route supports. Flag a blanket
+`catch` around the fixed attempt (it retries limit and unsupported-pair failures
+that the other rate type rejects identically), any fallback reachable after an
+order was created, and a fallback whose comment does not name the missing
+provider capability. Where the provider does expose per-route rate types, select
+explicitly instead of inferring from a failure.
 
 ## Chain Mappings
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Edge Exchange Plugins - Agent Guidelines
+# Edge Exchange Plugins - agent guidelines
 
 Swap and exchange-rate plugins loaded by `edge-core-js`. Each plugin adapts one
 provider's API to the `EdgeSwapPlugin` interface: quote a pair, map the
@@ -45,6 +45,9 @@ units**. Provider APIs almost always speak **decimal denominated** amounts.
   string comparisons silently misread.
 - Never assume a provider's documented unit. Several providers document base
   units and return decimals; check a live response.
+- `docs/API_REQUIREMENTS.md` asks partners for native units. That is what Edge
+  asks for, not a fact about any given provider. Most existing integrations
+  predate the request and send decimals.
 
 ## Starting a new provider
 
@@ -54,11 +57,17 @@ the invariants that recur in review (the max-quote probe, the trust boundary on
 provider-returned amounts, memo cleaning, limit direction). Copy it and keep the
 comments for the constructs you keep.
 
+Read [`docs/API_REQUIREMENTS.md`](./docs/API_REQUIREMENTS.md) before writing any
+of it, not only when deciding whether to take a provider on. It states what Edge
+asks every provider for, so it tells you which gaps you are about to work around
+belong to the provider rather than to the plugin. A workaround for a requirement
+the provider owes is worth raising with them before it becomes permanent.
+
 `src/swap/central/nym.ts` is the closest reviewed reference implementation.
 
 ## Docs
 
 - [`docs/CREATING_AN_EXCHANGE_PLUGIN.md`](./docs/CREATING_AN_EXCHANGE_PLUGIN.md) - build a plugin, plus the pre-PR checklist. Read before writing one
-- [`docs/API_REQUIREMENTS.md`](./docs/API_REQUIREMENTS.md) - what a provider's API must offer. Read when evaluating a new provider or arguing a gap back to them
+- [`docs/API_REQUIREMENTS.md`](./docs/API_REQUIREMENTS.md) - what a provider's API must offer. **Read before implementing a plugin**, as well as when evaluating a new provider or arguing a gap back to them
 - [`docs/CHAIN_MAPPING_SYNCHRONIZERS.md`](./docs/CHAIN_MAPPING_SYNCHRONIZERS.md) - keeping `src/mappings/*` in sync with a provider's chain list
 - [`.cursor/BUGBOT.md`](./.cursor/BUGBOT.md) - standing conventions for PR review on this repo

--- a/docs/API_REQUIREMENTS.md
+++ b/docs/API_REQUIREMENTS.md
@@ -4,46 +4,46 @@ Technical API requirements for third-party exchange providers integrating with t
 
 These requirements exist to enable smooth integration across three Edge repositories:
 
-- **[edge-exchange-plugins](https://github.com/AirshipApp/edge-exchange-plugins)** — swap plugins that call the provider API and map responses to Edge core types (`EdgeSwapQuote`, `EdgeTxActionSwap`, etc.)
-- **[edge-react-gui](https://github.com/AirshipApp/edge-react-gui)** — the wallet UI that displays quotes, errors, transaction details, and opens provider status pages
-- **[edge-reports-server](https://github.com/AirshipApp/edge-reports-server)** — the reporting pipeline that queries provider APIs and normalizes transactions into `StandardTx` records for revenue analytics
+- **[edge-exchange-plugins](https://github.com/AirshipApp/edge-exchange-plugins)**: swap plugins that call the provider API and map responses to Edge core types (`EdgeSwapQuote`, `EdgeTxActionSwap`, etc.)
+- **[edge-react-gui](https://github.com/AirshipApp/edge-react-gui)**: the wallet UI that displays quotes, errors, transaction details, and opens provider status pages
+- **[edge-reports-server](https://github.com/AirshipApp/edge-reports-server)**: the reporting pipeline that queries provider APIs and normalizes transactions into `StandardTx` records for revenue analytics
 
-Field names and JSON shapes in this document are illustrative — the plugin layer handles mapping between provider-specific names and Edge types. What matters is that the **information** is available and machine-readable.
+Field names and JSON shapes in this document are illustrative. The plugin layer maps between provider-specific names and Edge types, so the requirement is on the **information**, which must be present and machine-readable.
 
 **All requirements are mandatory** unless explicitly stated otherwise.
 
-### Table of Contents
+### Table of contents
 
 **General principles:**
 
-- [Amount Representation](#amount-representation)
+- [Amount representation](#amount-representation)
 
 **Requirements for all providers:**
 
-1. [Chain and Token Identification](#1-chain-and-token-identification)
-2. [Order Identification and Status Page](#2-order-identification-and-status-page)
-3. [Error Handling](#3-error-handling)
-4. [Quoting Requirements](#4-quoting-requirements)
-5. [Transaction Status API](#5-transaction-status-api)
+1. [Chain and token identification](#1-chain-and-token-identification)
+2. [Order identification and status page](#2-order-identification-and-status-page)
+3. [Error handling](#3-error-handling)
+4. [Quoting requirements](#4-quoting-requirements)
+5. [Transaction status API](#5-transaction-status-api)
 6. [Reporting API](#6-reporting-api)
-7. [Account Activation](#7-account-activation)
-8. [Affiliate Revenue Withdrawal](#8-affiliate-revenue-withdrawal)
+7. [Account activation](#7-account-activation)
+8. [Affiliate revenue withdrawal](#8-affiliate-revenue-withdrawal)
 
 **Additional requirements for fiat on/off ramp providers:**
 
-9. [User Authentication](#9-user-authentication)
-10. [Regional and Fiat Currency Support](#10-regional-and-fiat-currency-support)
-11. [KYC Information](#11-kyc-information)
-12. [Bank Information](#12-bank-information)
+9. [User authentication](#9-user-authentication)
+10. [Regional and fiat currency support](#10-regional-and-fiat-currency-support)
+11. [KYC information](#11-kyc-information)
+12. [Bank information](#12-bank-information)
 13. [Verification](#13-verification)
 14. [Widget Return URIs](#14-widgets)
-15. [Off-Ramp Flow](#15-off-ramp-flow)
+15. [Off-ramp flow](#15-off-ramp-flow)
 
 ---
 
-## General Principles
+## General principles
 
-### Amount Representation
+### Amount representation
 
 Amounts **should** be expressed in the asset's **native (smallest indivisible) units** rather than display units:
 
@@ -54,47 +54,53 @@ Amounts **should** be expressed in the asset's **native (smallest indivisible) u
 | SOL | lamports | `1500000000` |
 | USDC (6 decimals) | micro-units | `1500000` |
 
-Edge swap plugins convert between native and display units using `denominationToNative` / `nativeToDenomination` (see [`CREATING_AN_EXCHANGE_PLUGIN.md`](./CREATING_AN_EXCHANGE_PLUGIN.md) Step 5), so display-unit APIs are workable. However, if native units are not used, the API **must** clearly document which unit convention applies to every amount field so the plugin can convert correctly.
+This applies to **every** amount field in this document: quoted amounts (section 4), limit amounts in error responses (section 3), and transaction amounts in reporting records (section 6). No section carries a different convention.
+
+Native amounts for high-decimal assets run past the IEEE-754 safe integer range (1 ETH is `1000000000000000000` wei, well beyond 2^53), so they **should** be sent as JSON **strings** rather than numbers.
+
+Edge swap plugins convert between native and display units using `denominationToNative` / `nativeToDenomination` (see [`CREATING_AN_EXCHANGE_PLUGIN.md`](./CREATING_AN_EXCHANGE_PLUGIN.md) Step 5), so display-unit APIs are workable. If native units are not used, the API **must** clearly document which unit convention applies to every amount field so the plugin can convert correctly.
+
+Every example in this document annotates its native amounts with the display equivalent in a trailing comment. The comments are documentation, not part of the payload.
 
 ---
 
-## Requirements for All Providers
+## Requirements for all providers
 
-### 1. Chain and Token Identification
+### 1. Chain and token identification
 
-The API **must** accept a unique chain identifier and token identifier (such as the contract address) when requesting quotes and creating orders. It is **not** sufficient to only provide a separate "list all assets" endpoint — the exact asset must be specifiable in the quote/order request itself.
+The API **must** accept a unique chain identifier and token identifier (such as the contract address) when requesting quotes and creating orders. It is **not** sufficient to only provide a separate "list all assets" endpoint: the exact asset must be specifiable in the quote/order request itself.
 
-Edge exchange plugins maintain a mapping file (`src/mappings/<provider>.ts`) that translates Edge `pluginId` values (e.g. `'ethereum'`, `'bitcoin'`, `'solana'`) to the provider's chain codes. The provider's identifiers do not need to match Edge's — they just need to be stable and unique per chain.
+Edge exchange plugins maintain a mapping file (`src/mappings/<provider>.ts`) that translates Edge `pluginId` values (e.g. `'ethereum'`, `'bitcoin'`, `'solana'`) to the provider's chain codes. The provider's identifiers do not need to match Edge's, but they must be stable and unique per chain.
 
-For EVM chains, the API **should** accept the standard numeric EVM `chainId` (e.g. `1` for Ethereum, `56` for BNB Smart Chain). This avoids ambiguity with provider-specific EVM network names.
+For EVM chains, the API **must** accept the standard numeric EVM `chainId` (e.g. `1` for Ethereum, `56` for BNB Smart Chain). Numeric chain ids let a newly listed EVM work the day it is added, with no new entry in the plugin's mapping file, and they avoid ambiguity with provider-specific EVM network names.
 
 For tokens, the API **must** accept the on-chain contract address (or equivalent identifier) to distinguish tokens on the same chain.
 
-**Example — non-EVM asset:**
+**Example: non-EVM asset**
 
 ```json
 {
   "network": "solana",
-  "contractAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+  "contractAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" // USDC
 }
 ```
 
-**Example — EVM asset:**
+**Example: EVM asset**
 
 ```json
 {
   "network": "bsc",
-  "evmChainId": 56,
-  "contractAddress": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"
+  "evmChainId": 56, // BNB Smart Chain
+  "contractAddress": "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d" // USDC
 }
 ```
 
-### 2. Order Identification and Status Page
+### 2. Order identification and status page
 
 - Every order/quote response **must** include a unique order identifier that the plugin can store as `orderId` on the `EdgeTxActionSwap` (swap) or `EdgeTxActionFiat` (fiat) saved with the transaction. This same identifier must be usable to query the Transaction Status API (section 5) via an **unauthenticated** endpoint, and must match records in the Reporting API (section 6).
 - The provider **must** host an unauthenticated, user-facing status page accessible by order identifier. The Edge GUI opens this URL (stored as `orderUri` on the transaction action) so users can track their order outside the app. Example: `https://provider.com/status/{orderId}`
 
-### 3. Error Handling
+### 3. Error handling
 
 When a quote request fails or has issues, the API **must** return **all** applicable errors in a **single response** as structured JSON with machine-readable error codes. The exchange plugin determines error priority and maps to the appropriate Edge error class. Returning only a human-readable string message is not acceptable.
 
@@ -111,27 +117,30 @@ The plugin maps provider errors to these Edge error classes (defined in `edge-co
 
 #### Why both source and destination limits are needed
 
-Edge supports bi-directional quoting — the user may be specifying either the source amount or the destination amount (`quoteFor: 'from' | 'to'`). The plugin selects the appropriate limit based on which side the user specified:
+Edge supports bi-directional quoting, so the user may be specifying either the source amount or the destination amount (`quoteFor: 'from' | 'to'`). The plugin selects the appropriate limit based on which side the user specified:
 
 ```typescript
-const nativeLimit = denominationToNative(
-  quoteFor === 'from' ? request.fromWallet : request.toWallet,
-  quoteFor === 'from' ? limitError.sourceLimitAmount : limitError.destinationLimitAmount,
-  quoteFor === 'from' ? request.fromTokenId : request.toTokenId
-)
+const limitAmount =
+  quoteFor === 'from'
+    ? limitError.sourceLimitAmount
+    : limitError.destinationLimitAmount
 ```
 
 If the API can only return one side, the plugin cannot display the correct limit when the user quotes from the other direction.
 
 #### Example structured error response
 
+A BTC to USDT quote that is both above the limit and region restricted. Both
+errors come back in the one response, and both limit fields carry the same cap
+expressed in each asset.
+
 ```json
 {
   "errors": [
     {
       "code": "ABOVE_LIMIT",
-      "sourceLimitAmount": "0.009789",
-      "destinationLimitAmount": "1000000"
+      "sourceLimitAmount": "978900000", // 9.789 BTC in satoshis
+      "destinationLimitAmount": "1000000000000" // 1,000,000 USDT in micro-units
     },
     {
       "code": "REGION_UNSUPPORTED"
@@ -140,15 +149,15 @@ If the API can only return one side, the plugin cannot display the correct limit
 }
 ```
 
-Limit amounts in error responses are expected in **display units**, not [native units](#amount-representation). This is the one place the native-unit preference does not apply: the plugin passes these values straight into `denominationToNative` before constructing the Edge error, as shown above. If the API returns limits in native units instead, it **must** say so explicitly so the plugin can skip the conversion.
+Limit amounts **should** use [native units](#amount-representation), the same as every other amount in this document. Native units are integers, so a limit expressed in them always lands on a whole atomic unit, which is what Edge's limit errors carry. A display-unit limit carrying more decimal places than the asset's denomination holds does not: the plugin multiplies it up, gets a fractional native value, and has to pick a rounding direction for a bound it did not set. If the API returns limits in display units, it **must** document that convention, as [Amount Representation](#amount-representation) requires for every amount field, and the plugin converts with `denominationToNative`.
 
-The exact field names and code strings can vary — the plugin defines cleaners to parse the provider's specific format. What matters is that:
+The exact field names and code strings can vary, since the plugin defines cleaners for the provider's specific format. The requirements are:
 1. All errors are returned at once (not just the first one)
 2. Error types are machine-readable codes (not embedded in human-readable messages)
 3. Limit errors include amounts for both sides of the trade
 4. The unit convention for limit amounts is documented and consistent
 
-**Incorrect — unstructured string message:**
+**Incorrect, an unstructured string message:**
 
 ```json
 {
@@ -156,15 +165,23 @@ The exact field names and code strings can vary — the plugin defines cleaners 
 }
 ```
 
-### 4. Quoting Requirements
+The defect there is the shape, not the amount. A limit buried in a human-readable sentence cannot be parsed into a `SwapBelowLimitError` at all, whichever units it is written in.
+
+### 4. Quoting requirements
 
 The API **must** support bi-directional quoting: the user can specify either the source amount or the destination amount, and the API returns the corresponding counterpart. In Edge, this maps to `EdgeSwapRequest.quoteFor: 'from' | 'to' | 'max'`.
 
-Additionally, the API **should** support a "max" quote where the user wants to swap their entire balance. If the API does not support this natively, the plugin will emulate it by querying the user's balance and requesting a `'from'` quote with that amount.
+The API **should** also support a "max" quote where the user wants to swap their entire balance. If the API does not support this natively, the plugin will emulate it by querying the user's balance and requesting a `'from'` quote with that amount.
 
-Quoted amounts **should** use [native units](#amount-representation) where possible. If the API quotes in display units, it must document that convention (see [Amount Representation](#amount-representation)) so the plugin converts correctly.
+Quoted amounts **should** use [native units](#amount-representation), the same as every other amount in this document. If the API quotes in display units, it **must** document that convention (see [Amount representation](#amount-representation)) so the plugin converts correctly.
 
-### 5. Transaction Status API
+#### Rate types
+
+Where the provider offers more than one rate type (fixed, floating), the API **must** expose which types a given route supports, so the client selects a type rather than attempting one and inferring support from the failure. Where only one type is available for a route, the quote response **must** state which.
+
+Inferring support from a failure is unreliable in both directions: a provider that answers `5xx` for a route it cannot fix is indistinguishable from an outage, and a provider that accepts an unrecognized rate-type value silently downgrades every quote.
+
+### 5. Transaction status API
 
 The provider **must** expose an **unauthenticated** endpoint that accepts the order identifier (from section 2) and returns the current transaction status. Edge queries this without partner credentials, so it must not require an API key.
 
@@ -184,9 +201,9 @@ The `edge-reports-server` normalizes provider statuses to this set when writing 
 | `blocked` | Order held for review |
 | `other` | Catch-all for provider-specific states |
 
-The provider does not need to use these exact strings — each reporting plugin maps the provider's native status values. However, the API **must** distinguish at minimum between: pending/in-progress, completed, expired, and refunded/failed states.
+The provider does not need to use these exact strings, since each reporting plugin maps the provider's native status values. The API **must** still distinguish at minimum between: pending/in-progress, completed, expired, and refunded/failed states.
 
-Providers that can stall an order pending user input (most fiat ramps, where KYC documents or additional details are outstanding) **must** additionally expose an **`infoNeeded`** state, distinct from generic pending. Edge uses it to prompt the user rather than leave them waiting on an order that will never progress on its own. `StandardTx` has no dedicated value for this, so reporting plugins currently normalize it to `blocked`; the distinction matters at the status API and in the GUI, not in reports.
+Providers that can stall an order pending user input (most fiat ramps, where KYC documents or additional details are outstanding) **must** also expose an **`infoNeeded`** state, distinct from generic pending. Edge uses it to prompt the user rather than leave them waiting on an order that will never progress on its own. `StandardTx` has no dedicated value for this, so reporting plugins currently normalize it to `blocked`; the distinction matters at the status API and in the GUI, not in reports.
 
 ### 6. Reporting API
 
@@ -194,15 +211,13 @@ The provider **must** expose an authenticated API that returns all transactions 
 
 #### Pagination and filtering
 
-The API **must** support incremental querying so the reporting pipeline can efficiently poll for new transactions. Acceptable approaches include:
+The API **must** support paginated queries filtered by a **start date**, an **end date**, and a **maximum record count**, so the reporting pipeline can poll incrementally for new transactions instead of re-reading the full history on every run.
 
-- Date range filtering (start/end date) with pagination (limit/offset or cursor)
-- Offset-based pagination with a reasonable page size
-- Cursor/bookmark-based pagination
+Pagination within that date range may be offset-based or cursor/bookmark-based; either is acceptable. The date range itself is not optional: without it the pipeline cannot bound a query to the window it has not yet ingested.
 
 #### Required data per transaction
 
-Each transaction record must include enough information for the reporting plugin to populate a `StandardTx`. The field names below are from the `StandardTx` type — the provider's field names will differ and the plugin handles the mapping:
+Each transaction record must include enough information for the reporting plugin to populate a `StandardTx`. The field names below are from the `StandardTx` type; the provider's names will differ, and the plugin handles the mapping:
 
 | `StandardTx` field | Description | Required |
 |---|---|---|
@@ -212,25 +227,28 @@ Each transaction record must include enough information for the reporting plugin
 | (no field yet) | Order **completion** date, when the order reached a terminal status | Yes, see below |
 | `depositCurrency` / `payoutCurrency` | Currency codes for source and destination | Yes |
 | `depositAmount` / `payoutAmount` | Amounts for source and destination | Yes |
-| `depositAddress` / `payoutAddress` | Deposit and withdrawal addresses | Recommended |
-| `depositTxid` / `payoutTxid` | On-chain transaction IDs | Recommended |
-| `depositTokenId` / `payoutTokenId` | Token contract address, or `null` for native assets | Recommended |
-| `depositEvmChainId` / `payoutEvmChainId` | Numeric EVM chain ID if applicable | Recommended for EVM chains |
+| `depositAddress` / `payoutAddress` | Deposit and withdrawal addresses | Yes |
+| `depositTxid` / `payoutTxid` | On-chain transaction IDs | Yes |
+| `depositChainPluginId` / `payoutChainPluginId` | Chain identifier for each side (e.g. `"solana"`, `"bitcoin"`) | Yes |
+| `depositTokenId` / `payoutTokenId` | Token contract address, or `null` for native assets | Yes |
+| `depositEvmChainId` / `payoutEvmChainId` | Numeric EVM chain ID for the side, whenever that side is an EVM chain | Yes, for EVM chains |
 | `countryCode` | User's country (ISO 3166-1 alpha-2) | Fiat providers only |
 | `direction` | `'buy'` or `'sell'` (fiat) or `null` (swap) | Fiat providers only |
 | `paymentType` | Payment method (e.g. `'sepa'`, `'credit'`, `'ach'`) | Fiat providers only |
 
 **Both dates are required from the provider.** The response **must** carry the order creation date and, for orders in a terminal status, the completion/settlement date. `StandardTx` currently persists only the creation date (as `isoDate` and `timestamp`) and has no completion field, so the completion date survives only inside `rawTx` today. Providers should still return it: settlement time is needed for partner reporting, and the field is expected to be promoted to a first-class `StandardTx` column.
 
-Amount fields (`depositAmount`, `payoutAmount`, `usdValue`) are **display-unit numbers**, not [native units](#amount-representation). `StandardTx` types them via `asSafeNumber`, so native units for high-decimal assets would overflow the safe integer range. The reporting plugin converts if the provider reports natively, but the API **must** document which convention it uses.
+Reported amounts **should** use [native units](#amount-representation), the same as every other amount in this document. If the API reports in display units, it **must** document that convention.
+
+`StandardTx` itself stores `depositAmount`, `payoutAmount` and `usdValue` as **display-unit numbers**: it types them via `asSafeNumber`, and native units on a high-decimal asset would overflow the safe integer range. That constrains Edge's storage, not the provider's wire format, and converting into it is the reporting plugin's job.
 
 The reporting plugin also stores the raw provider response in `rawTx` for auditing, so including additional metadata in the response is helpful.
 
-### 7. Account Activation
+### 7. Account activation
 
-Some blockchain networks (e.g. XRP, HBAR, Tron) require account activation or reserve balances before an address can receive funds. For any such network the provider supports, the provider **must** detect unactivated destination addresses and handle activation as part of the withdrawal — without requiring additional action from the user or from Edge.
+Some blockchain networks require account activation or a reserve balance before an address can receive funds, XRP, HBAR and Tron among them. For any such network the provider supports, the provider **must** detect unactivated destination addresses and handle activation as part of the withdrawal, without requiring additional action from the user or from Edge.
 
-### 8. Affiliate Revenue Withdrawal
+### 8. Affiliate revenue withdrawal
 
 - The provider **must** automatically withdraw affiliate revenue no later than **24 hours after each month-end (GMT)**. Edge should **not** be required to initiate withdrawals.
 - Withdrawal must be supported in at least **BTC, ETH, and USDC** to a fixed address verified by Edge.
@@ -238,22 +256,23 @@ Some blockchain networks (e.g. XRP, HBAR, Tron) require account activation or re
 
 ---
 
-## Additional Requirements for Fiat On/Off Ramp Providers
+## Additional requirements for fiat on/off ramp providers
 
 Fiat providers in Edge are integrated through the GUI's fiat plugin system (`edge-react-gui/src/plugins/gui/`). Each provider implements the `FiatProvider` interface, which receives quote parameters including region, fiat currency, payment type, and crypto asset. The requirements below ensure the provider API supports the data flows this system needs.
 
-### 9. User Authentication
+### 9. User authentication
 
-The provider **must** support a way for Edge to authenticate users programmatically — without requiring the user to create an account on the provider's website. Edge generates a unique per-user identifier and passes it to the provider with every request.
+The provider **must** support a way for Edge to authenticate users programmatically, without requiring the user to create an account on the provider's website. Edge generates a **cryptographically random** per-user identifier (`authKey`) and passes it with every quoting and order execution request.
 
-The implementation can be:
-- An API key or token that Edge generates and the provider associates with a user account
-- A device-based identifier that the provider uses to create and retrieve user sessions
-- A signed challenge/response flow
+The provider can consume that identifier however it likes:
 
-The key requirement is that user creation and authentication happen through API calls, not through an external registration page.
+- Treat it as an API key or token and associate it with a user account
+- Use it to create and retrieve a user session
+- Key a signed challenge/response flow to it
 
-### 10. Regional and Fiat Currency Support
+The identifier **must** originate with Edge, not with the provider. When it names a user the provider has not seen before, account creation **must** proceed through the API by accepting KYC information (section 11), never through an external registration page.
+
+### 10. Regional and fiat currency support
 
 The quoting API **must** accept the user's region and fiat currency. In Edge, region is represented as:
 
@@ -266,7 +285,7 @@ interface FiatPluginRegionCode {
 
 The API **must** return structured errors (see [section 3](#3-error-handling)) for unsupported regions and unsupported fiat currencies. In Edge, these map to `FiatProviderError` with `errorType: 'regionRestricted'` and `errorType: 'fiatUnsupported'` respectively.
 
-### 11. KYC Information
+### 11. KYC information
 
 The provider API **must** allow Edge to submit KYC information **via API** (not via a widget or redirect):
 
@@ -277,7 +296,7 @@ The provider API **must** allow Edge to submit KYC information **via API** (not 
 
 Additional verification steps (e.g. document upload, facial recognition) may use a widget (see section 14), but basic identity information must be submittable programmatically.
 
-### 12. Bank Information
+### 12. Bank information
 
 For payment methods that require bank details (e.g. wire transfers, SEPA, ACH), the provider **must** expose an API for Edge to submit bank account information. The API should support the relevant identifiers for its operating regions (IBAN, account number + routing number, etc.).
 
@@ -288,15 +307,18 @@ For payment methods that require bank details (e.g. wire transfers, SEPA, ACH), 
 
 ### 14. Widgets
 
-Any required widgets (e.g. for credit card entry, document upload, or biometric scans) **must** support closing and returning to the Edge app. Acceptable approaches:
+Any required widgets (e.g. for credit card entry, document upload, or biometric scans) **must** accept a return URI / redirect URL parameter from Edge, so the widget redirects back once it completes and the app can resume its flow.
 
-- Accept a return URI / redirect URL parameter so the webview can navigate back to Edge
-- Support deep link callbacks that Edge can listen for
-- Provide a clear "done" signal (URL navigation to a known path, postMessage, etc.) that Edge can detect to close the webview
+Any step that takes a card payment, Apple Pay, or Google Pay has to run in the system browser (SafariView on iOS, Custom Tabs on Android). Those payment methods are unavailable to an embedded WebView, and an embedded WebView is a surface the host app can inject JavaScript into, which no card processor accepts for cardholder data entry. Edge cannot observe that page, so a redirect to a URI Edge registered is the only route back.
 
-The Edge GUI displays widgets in either an in-app WebView or an external browser (SafariView / Custom Tabs). Both flows need a way to detect completion and return control to the app.
+Edge does display widgets in its own WebView for steps that take no payment, such as bank-account linking and sell flows, and there a completion signal Edge can observe is workable too:
 
-### 15. Off-Ramp Flow
+- Navigation to a known path
+- A `postMessage` to the host
+
+Neither carries over to the system browser, so a widget offering only these cannot host a payment step.
+
+### 15. Off-ramp flow
 
 For off-ramp (sell) transactions where the user has already completed KYC and linked a payment method, the provider **must** support a **fully API-driven flow** (no widget required) by returning:
 

--- a/docs/CREATING_AN_EXCHANGE_PLUGIN.md
+++ b/docs/CREATING_AN_EXCHANGE_PLUGIN.md
@@ -1,42 +1,43 @@
-# Creating an Exchange Plugin
+# Creating an exchange plugin
 
-This guide walks you through creating a new exchange plugin for Edge. **Before starting, review [`API_REQUIREMENTS.md`](./API_REQUIREMENTS.md)** which outlines mandatory API specifications.
+Review [`API_REQUIREMENTS.md`](./API_REQUIREMENTS.md) before starting. It states what a provider's API must offer, and a gap there is the provider's to close rather than something the plugin works around.
 
-## Table of Contents
+## Table of contents
 
 - [Prerequisites](#prerequisites)
-- [Plugin Types](#plugin-types)
-- [Getting Started](#getting-started)
-- [Implementation Steps](#implementation-steps)
-- [Code Conventions](#code-conventions)
-- [Testing & Registration](#testing--registration)
+- [Plugin types](#plugin-types)
+- [Getting started](#getting-started)
+- [Implementation steps](#implementation-steps)
+- [Code conventions](#code-conventions)
+- [Testing & registration](#testing--registration)
 - [Resources](#resources)
+- [Pre-PR checklist](#pre-pr-checklist)
 
 ## Prerequisites
 
-**Review [`API_REQUIREMENTS.md`](./API_REQUIREMENTS.md)** to ensure your exchange provider meets all requirements including: chain/token identification, error handling, bi-directional quoting, transaction status APIs, and reporting APIs.
+[`API_REQUIREMENTS.md`](./API_REQUIREMENTS.md) covers chain and token identification, error handling, bi-directional quoting, the transaction status API, and the reporting API. Confirm the provider meets those before writing code.
 
-### Development Environment
+### Development environment
 
 1. Clone `edge-exchange-plugins` as a peer to `edge-react-gui`
 2. Install: `npm install && npm run prepare`
 3. Review `src/swap/central/template.ts` as a complete example
 
-## Plugin Types
+## Plugin types
 
 **Centralized Exchange Plugins** (`src/swap/central/`): Traditional exchanges (ChangeNOW, Exolix, etc.) that handle swaps through their infrastructure. Use API keys, deposit addresses, and order IDs.
 
 **DeFi Exchange Plugins** (`src/swap/defi/`): Decentralized exchanges (LI.FI, THORChain, etc.) that execute on-chain. May require token approvals and handle on-chain transaction construction.
 
-## Getting Started
+## Getting started
 
 1. Choose location: `src/swap/central/yourplugin.ts` or `src/swap/defi/yourplugin.ts`
 2. Copy `src/swap/central/template.ts` as your base
 3. Study similar plugins: `exolix.ts` (central) or `lifi.ts` (DeFi)
 
-## Implementation Steps
+## Implementation steps
 
-### Step 1: Plugin Metadata
+### Step 1: Plugin metadata
 
 ```typescript
 const pluginId = 'yourplugin'
@@ -49,7 +50,7 @@ export const swapInfo: EdgeSwapInfo = {
 }
 ```
 
-### Step 2: Initialization Options
+### Step 2: Initialization options
 
 ```typescript
 import { asObject, asOptional, asString } from 'cleaners'
@@ -60,15 +61,15 @@ const asInitOptions = asObject({
 })
 ```
 
-### Step 3: Chain Code Mapping
+### Step 3: Chain code mapping
 
 Each plugin needs a mapping file in `src/mappings/` that translates Edge currency plugin IDs to your exchange provider's chain codes. **For EVM chains, use `evmChainId` (not provider-specific network names)** per API requirements.
 
-#### Creating the Mapping File
+#### Creating the mapping file
 
 Follow the [Chain Mapping Synchronizers](./CHAIN_MAPPING_SYNCHRONIZERS.md) guide to set up automated synchronization for your mapping file. This fetches supported chains from your provider's API and keeps the mapping up-to-date.
 
-#### Using the Mapping in Your Plugin
+#### Using the mapping in your plugin
 
 Import and use the mapping directly:
 
@@ -86,7 +87,7 @@ if (fromMainnetCode == null || toMainnetCode == null) {
 
 > **Note**: Some existing plugins convert the Map to an object using `mapToStringMap()` or `mapToRecord()` from `swapHelpers.ts`. This is a legacy pattern - new plugins can use the Map directly.
 
-#### Manual Mapping (Alternative)
+#### Manual mapping (alternative)
 
 For providers without a chain configuration API, you can manually create and maintain `src/mappings/yourplugin.ts`:
 
@@ -101,7 +102,7 @@ yourplugin.set('unsupportedchain', null)  // null = not supported by provider
 // ... map all Edge plugin IDs to your provider's chain codes
 ```
 
-### Step 4: Quote Fetching
+### Step 4: Quote fetching
 
 The `fetchSwapQuote` function must:
 1. Call `checkInvalidTokenIds()` before touching the network, so blocked assets
@@ -113,7 +114,7 @@ The `fetchSwapQuote` function must:
 6. Create `EdgeSpendInfo` or `MakeTxParams`
 7. Return quote using `makeSwapPluginQuote()`
 
-### Step 4b: Max Quotes
+### Step 4b: Max quotes
 
 A `max` request arrives carrying the wallet's **raw, pre-fee balance**.
 `getMaxSwappable()` invokes your quote function as a probe with that balance,
@@ -141,7 +142,7 @@ const newRequest = await getMaxSwappable(fetchProbeOrder, request)
 const swapOrder = await fetchSwapQuoteInner(newRequest) // creates the order, once
 ```
 
-Three details are load-bearing, and each has broken a shipped plugin:
+Each of these has broken a shipped plugin:
 
 - **The probe must not create an order.** Otherwise every max swap creates and
   abandons a live order, which also burns the budget of any provider that
@@ -160,17 +161,24 @@ If the provider has no separate quote endpoint (order creation *is* the quote),
 say so in a comment. The abandoned probe order is then inherent rather than a
 plugin defect.
 
-### Step 5: Amount Conversions
+### Step 5: Amount conversions
 
 ```typescript
+import { floor } from 'biggystring'
+
 import { denominationToNative, nativeToDenomination } from '../../util/swapHelpers'
 
 // To API
 const apiAmount = nativeToDenomination(wallet, nativeAmount, tokenId)
 
-// From API — round to whole atomic units
+// From API: round to whole atomic units
 const nativeAmount = floor(denominationToNative(wallet, apiAmount, tokenId), 0)
 ```
+
+Convert only when the provider speaks denominated amounts. Sections 3, 4 and 6 of
+[`API_REQUIREMENTS.md`](./API_REQUIREMENTS.md) ask partners for native units, so a
+provider that complies needs no conversion on the way in, and converting anyway
+inflates the value by 10^decimals.
 
 `denominationToNative` is a plain multiply, so a provider amount carrying more
 decimals than the asset's denomination returns a **fraction**
@@ -193,11 +201,11 @@ Never assume the provider's documented unit. Docs claiming base units while the
 API returns decimals is common, and the mistake is invisible whenever the pairs
 used during development return null limits.
 
-### Step 6: Error Handling
+### Step 6: Error handling
 
 **The API must return all applicable errors in an array.** Your plugin prioritizes which error to throw.
 
-Four rules, each from a shipped defect:
+Each rule below comes from a shipped defect:
 
 1. **Limit errors outrank currency errors.** A limit failure whose code or
    message also names a token, path or route must still surface as
@@ -247,7 +255,10 @@ const asErrorResponse = asObject({
 Handle errors in priority order:
 
 ```typescript
+import { ceil, floor } from 'biggystring'
 import { SwapAboveLimitError, SwapBelowLimitError, SwapCurrencyError, SwapPermissionError } from 'edge-core-js/types'
+
+import { denominationToNative } from '../../util/swapHelpers'
 
 if ('errors' in quoteReply) {
   // Throw errors in order of highest priority
@@ -270,11 +281,19 @@ if ('errors' in quoteReply) {
   const limitError = errors.find(e => e.code === 'BELOW_LIMIT' || e.code === 'ABOVE_LIMIT')
   if (limitError && 'sourceLimitAmount' in limitError) {
     if (quoteFor === 'max') throw new Error('Max quote cannot return limit error')
-    const nativeLimit = denominationToNative(
-      quoteFor === 'from' ? request.fromWallet : request.toWallet,
-      quoteFor === 'from' ? limitError.sourceLimitAmount : limitError.destinationLimitAmount,
-      quoteFor === 'from' ? request.fromTokenId : request.toTokenId
-    )
+    const limitAmount =
+      quoteFor === 'from' ? limitError.sourceLimitAmount : limitError.destinationLimitAmount
+    const limitWallet = quoteFor === 'from' ? request.fromWallet : request.toWallet
+    const limitTokenId = quoteFor === 'from' ? request.fromTokenId : request.toTokenId
+
+    // Confirm against a live response which units this provider sends. If it
+    // sends native units, drop the conversion; converting again inflates the
+    // limit by 10^decimals. Round toward the provider either way: a minimum up
+    // and a maximum down, so rounding never widens the range it accepts.
+    const nativeLimit =
+      limitError.code === 'BELOW_LIMIT'
+        ? ceil(denominationToNative(limitWallet, limitAmount, limitTokenId), 0)
+        : floor(denominationToNative(limitWallet, limitAmount, limitTokenId), 0)
     throw limitError.code === 'BELOW_LIMIT'
       ? new SwapBelowLimitError(swapInfo, nativeLimit, quoteFor)
       : new SwapAboveLimitError(swapInfo, nativeLimit, quoteFor)
@@ -284,7 +303,7 @@ if ('errors' in quoteReply) {
 }
 ```
 
-### Step 7: Transaction Information
+### Step 7: Transaction information
 
 For central exchanges, create `EdgeSpendInfo`:
 
@@ -312,7 +331,7 @@ const spendInfo: EdgeSpendInfo = {
 
 For DeFi exchanges, use `MakeTxParams` (see DeFi plugin examples).
 
-Three fields above are decisions, not boilerplate:
+These fields are decisions, not boilerplate:
 
 - **`orderUri` is built from your own constant** plus the order id. Never persist
   a partner-supplied `statusUrl`. It renders as a tappable link in the
@@ -337,18 +356,17 @@ if (request.quoteFor === 'from' && gt(fromNativeAmount, request.nativeAmount)) {
 
 Bound **every** field the spend path consumes, not only the most obvious one: on
 a DeFi route that includes the token-approval amount and any native value on the
-transaction. Compare each against a value in **its own units** — a native fee in
+transaction. Compare each against a value in **its own units**: a native fee in
 wei compared against a token amount in token base units falsely rejects valid
 quotes.
 
 Only a `from` quote pins the source amount locally. On a reverse (`to`) quote the
 user pinned the receive amount, so there is nothing local to bound against.
 
-### Step 8: API Response Validation
+### Step 8: API response validation
 
-Always use `cleaners` to validate API responses:
-
-Keep the **quote** and **order** responses as separate cleaners. What belongs to
+Every API response goes through a `cleaners` validator, and the **quote** and
+**order** responses get separate ones. What belongs to
 which is not cosmetic: a response carrying a `depositAddress` has committed the
 provider, so if `orderId` and `depositAddress` live on the quote cleaner then the
 quote call *is* an order call, and the max probe cannot avoid creating one no
@@ -384,13 +402,13 @@ a defect in the plugin, and reviewers have accepted that where it is true.
 `asMaybe(asString)`) has two failure modes that both silently send an *untagged*
 deposit, which loses funds on memo-based chains:
 
-- a **numeric** memo — the common shape for an XRP destination tag, including
-  the valid tag `0` — fails a string-only cleaner
+- a **numeric** memo fails a string-only cleaner. That is the common shape for
+  an XRP destination tag, including the valid tag `0`
 - an **empty string** becomes an empty `EdgeMemo` rather than no memo at all
 
 `asOptionalBlank(asNumberString)` covers both.
 
-Two more cleaner notes:
+Also:
 
 - Accept **numeric or string error codes**. A provider that returns amounts as
   either shape usually does the same with codes, and `asNumberString`
@@ -399,9 +417,8 @@ Two more cleaner notes:
   `undefined`. `asEither(asString, asNull)` is only needed when `null` and
   absent must stay distinguishable.
 
-## Code Conventions
+## Code conventions
 
-Follow Edge conventions:
 - **Code style**: [`edge-conventions/code/javascriptCode.md`](https://github.com/EdgeApp/edge-conventions/blob/master/code/javascriptCode.md) - Use `TODO + initials`, named exports only, Prettier formatting
 - **Setup**: [`edge-conventions/code/javascriptSetup.md`](https://github.com/EdgeApp/edge-conventions/blob/master/code/javascriptSetup.md)
 - **Git**: [`edge-conventions/git/commit.md`](https://github.com/EdgeApp/edge-conventions/blob/master/git/commit.md) - Imperative mood, 50 char subject, wrap body at 72 chars
@@ -412,7 +429,7 @@ Follow Edge conventions:
 
 **Error handling**: Always use Edge error types (`SwapCurrencyError`, etc.), never raw strings
 
-## Testing & Registration
+## Testing & registration
 
 ### Testing
 
@@ -434,20 +451,20 @@ Native JS context, so Metro's debugger and Hermes breakpoints cannot reach them.
 Verification means rebuilding the bundle, relinking, and reading plugin logs.
 Budget for that loop.
 
-**Exercise these paths specifically**, since they are where new plugins break
-and none of them show up in a happy-path quote:
+Exercise these paths specifically. They are where new plugins break, and none of
+them show up in a happy-path quote:
 
-- A **max** swap from an EVM wallet (catches a probe missing `skipChecks`)
-- A **max** swap from a wallet whose balance exceeds the provider maximum
-  (catches a probe that throws instead of clamping)
-- A **reverse** (`to`) quote, if the provider supports one
-- A swap to a **memo-based** chain such as XRP or XLM (catches a memo cleaner
-  that drops numeric tags)
-- An amount **below the minimum** and one **above the maximum**, checking the
-  figure the GUI actually shows
-- A **token** route, not only the native asset
-- A **pair the provider does not route**, confirming it fails as
-  `SwapCurrencyError` rather than a hard error
+- A max swap from an EVM wallet (catches a probe missing `skipChecks`)
+- A max swap from a wallet whose balance exceeds the provider maximum (catches a
+  probe that throws instead of clamping)
+- A reverse (`to`) quote, if the provider supports one
+- A swap to a memo-based chain such as XRP or XLM (catches a memo cleaner that
+  drops numeric tags)
+- An amount below the minimum and one above the maximum, checking the figure the
+  GUI actually shows
+- A token route, not only the native asset
+- A pair the provider does not route, confirming it fails as `SwapCurrencyError`
+  rather than a hard error
 
 ### Registration
 
@@ -483,17 +500,17 @@ Plugin ID must match your `pluginId` constant.
 - `utils.ts` - `getAddress`, `denominationToNative`, etc.
 - `edgeCurrencyPluginIds.ts` - Currency plugin ID constants
 
-**Chain Mappings**:
+**Chain mappings**:
 - `src/mappings/` - Chain code mapping files (Edge plugin IDs → provider codes)
 - See [Chain Mapping Synchronizers](./CHAIN_MAPPING_SYNCHRONIZERS.md) for automated sync setup
 
-**PR Requirements**:
+**PR requirements**:
 1. Rebase on master
 2. `npm run verify` passes (prepare, lint, tsc, mocha)
 3. Submit PRs to `edge-reports-server` (reporting) and `edge-react-gui` (UI/logos)
 4. Update docs if new patterns discovered
 
-## Pre-PR Checklist
+## Pre-PR checklist
 
 Every item below has been raised in review on a recent provider integration.
 Walking the list before opening the PR is cheaper than discovering them one


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [ ] Yes
- [x] No

### Dependencies

none

### Description

Doc-only. Makes native units the single amount convention in [`docs/API_REQUIREMENTS.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md), and restores six requirements that [`ff4cc3d`](https://github.com/EdgeApp/edge-exchange-plugins/commit/ff4cc3d5f41559b696b2b67b619f80aa24f8a470) weakened, each of them weaker than both [#442](https://github.com/EdgeApp/edge-exchange-plugins/pull/442) and the original requirements doc this file was transcribed from.

Found while grading SimpleSwap against this doc for [Asana 1217205278669378](https://app.asana.com/0/1215088146871429/1217205278669378), which surfaced the units contradiction in [section 3](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#3-error-handling). Auditing the rest of the revision turned up the other five.

The reference point throughout is Paul's ["2025 Exchange Provider API Requirements"](https://docs.google.com/document/d/1wSljZpR71C32tPKrG16fNv6K_FXeTwLfkhmmM0thqkg/edit) doc (last modified 2025-12-19), which [`ef51604`](https://github.com/EdgeApp/edge-exchange-plugins/commit/ef51604955c1799f6b8a83c124726abeb973feae) transcribes almost verbatim.

#### One unit convention, stated once

The document had drifted into three conventions at once. [Section 3](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#3-error-handling) asked for display units and described itself as "the one place the native-unit preference does not apply". [Section 6](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#6-reporting-api) asked for display units, citing `StandardTx`'s `asSafeNumber` typing. [Section 4](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#4-quoting-requirements) asked for native units.

All of it now reads the same way. [Amount representation](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#amount-representation) states outright that it governs every amount field and that no section carries a different convention, and sections 3, 4 and 6 use identical wording: native is a **should**, and a display-unit API **must** document that it is one.

The `asSafeNumber` fact moves to where it belongs. It constrains Edge's storage, not the provider's wire format, and the reporting plugin already converts, so it is now a note about `StandardTx` rather than an instruction to partners.

Worth stating plainly: the source doc has no unit convention anywhere. Its only amounts example sits inside the error-handling section, whose purpose is to show that every applicable error comes back in one response, so the display units in it are incidental to the point being made rather than a decision about units. Reading a convention out of an incidental example is exactly what drifted, twice. The native-unit preference was introduced by [#442](https://github.com/EdgeApp/edge-exchange-plugins/pull/442) and approved there; this PR makes it uniform rather than inventing it.

#### The 1000x error in [section 3](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#3-error-handling)'s example

The source doc's example is a BTC to USDT above-limit error:

```
"sourceAmountLimit": 9.789,        // BTC
"destinationAmountLimit": 1000000  // USDT
```

Those are not two unrelated numbers. 9.789 BTC and 1,000,000 USDT are the same $1M cap expressed in each asset, which is exactly what the section requires ("min/max amounts specified in both the source and destination asset").

[#442](https://github.com/EdgeApp/edge-exchange-plugins/pull/442) converted both to native units: `978900000` satoshis (9.789 BTC, correct) and
`1000000000000` micro-units ($1M USDT, correct). The pair stayed coherent. The only defect was the trailing comment: it read `0.009789 BTC` against a value of 9.789 BTC.

`ff4cc3d` resolved that mismatch by trusting the comment. It rewrote the source limit as the display string `"0.009789"`, roughly $1,000, and left the destination at 1,000,000 USDT. The two sides of one limit now differ by 1000x, and the section that exists to require both sides illustrates it with a pair that cannot both be true. That mismatch is the entire basis for the display-unit sentence `ff4cc3d` added.

The value is restored and the comment corrected.

Display-unit limits also cost something in the plugins. `denominationToNative` is a plain multiply, so a display-unit limit carrying more decimals than the asset's denomination lands on a fractional native value, and Edge limits must be whole atomic units. Each plugin is then left picking a rounding direction for a bound it did not set. Native units are integers, so the whole class disappears.

#### The six restorations

| # | Requirement | Source doc | [#442](https://github.com/EdgeApp/edge-exchange-plugins/pull/442) | `ff4cc3d` | Now |
|---|---|---|---|---|---|
| 1 | EVM `chainId` | must | must | should | must |
| 6 | Paginated queries with start date, end date, count | must | must | one of three optional approaches | must |
| 6 | `depositAddress`/`payoutAddress`, `depositTxid`/`payoutTxid`, `depositTokenId`/`payoutTokenId`, `depositEvmChainId`/`payoutEvmChainId` | must | must | Recommended | must |
| 6 | Chain identifier per side | must | must | **absent from the table** | must |
| 9 | `authKey` generated by Edge, cryptographically random | must | must | "a unique per-user identifier", provider-created sessions acceptable | must |
| 14 | Widget accepts a return URI from Edge | must | must | one of three equal alternatives | must |

Two of these change a live conformance verdict. SimpleSwap passes on EVM `chainId` and on reporting pagination only under the `ff4cc3d` text, and fails both against the source doc.

The dropped chain identifier is an outright bug rather than a relaxation. `ff4cc3d` rewrote the reporting table around `StandardTx` field names and lost `sourceNetwork` / `destinationNetwork` in the process, with no replacement row. [`StandardTx`](https://github.com/EdgeApp/edge-reports-server/blob/master/src/types.ts) has the field (`depositChainPluginId` / `payoutChainPluginId`), so the table was simply missing it, and as written a provider could satisfy every listed field while leaving Edge unable to tell which chain a contract address belongs to.

Section 1's restoration also brings back the reason the source doc gives, which went out with the obligation: numeric chain ids let a newly listed EVM work the day it is added, with no new entry in the plugin's mapping file. `ff4cc3d` replaced that with "avoids ambiguity with provider-specific EVM network names", a weaker claim supporting a weaker requirement.

Section 14 is the narrowest of the six: it sits under "Additional Requirements for Fiat On/Off Ramp Providers", so it binds fiat ramps only and no swap provider ever reaches it. `ff4cc3d` turned the return URI into one of three equal options, alongside a `postMessage` or navigation to a known path. Those are not equivalent. Any step taking a card payment, Apple Pay or Google Pay has to run in the system browser, both because those payment methods are unavailable to an embedded WebView and because an embedded WebView is a surface the host app can inject JavaScript into, which no card processor accepts for cardholder data entry. Edge cannot observe that page, so a redirect to a URI it registered is the only route back. The section keeps the observable signals, scoped to the non-payment steps Edge does display in its own WebView (bank linking, sell flows), and says plainly that a widget offering only those cannot host a payment step.

#### Examples

Every example now carries native amounts annotated with the display equivalent in a trailing comment, matching how the source doc and [#442](https://github.com/EdgeApp/edge-exchange-plugins/pull/442) wrote theirs. The asset and chain comments `ff4cc3d` dropped from the section 1 examples are back for the same reason.

One addition that is not a restoration: native amounts are now specified as JSON **strings**. A high-decimal asset in native units runs past the IEEE-754 safe integer range (1 ETH is 1e18 wei, well beyond 2^53), so a universal native-unit rule is unusable as JSON numbers. Section 3's example already used strings; this states why.

[Section 3](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#3-error-handling)'s counter-example (`"Amount is below the minimum of 0.0001 BTC"`) keeps its display amount, with a line noting that the defect there is the shape and not the units, so it does not get "fixed" into a native amount later.

#### [`CREATING_AN_EXCHANGE_PLUGIN.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/CREATING_AN_EXCHANGE_PLUGIN.md)

The plugin guide carried the same defect, in [the block plugin authors copy](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/CREATING_AN_EXCHANGE_PLUGIN.md#L284-L299). [Step 6](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/CREATING_AN_EXCHANGE_PLUGIN.md#step-6-error-handling)'s limit sample was byte-for-byte the code `ff4cc3d` had put in section 3, and it broke three ways at once: it converted unconditionally, so a provider that follows the new [section 3](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#3-error-handling) gets multiplied twice and shows a limit inflated by 10^decimals; it did not round; and it derived one `nativeLimit` and threw it as both `SwapBelowLimitError` and `SwapAboveLimitError`, so no single rounding direction could have been correct for it.

The second of those predates this branch. That sample failed the guide's own [pre-PR checklist](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/CREATING_AN_EXCHANGE_PLUGIN.md#pre-pr-checklist), printed 230 lines below it, which already required every `denominationToNative` result to be rounded and minimums to round up. Two plugins now on unmerged branches carry a hand-retrofitted version of the same fix.

The sample now selects the side, rounds a minimum up and a maximum down, and says in a comment that the unit convention has to be confirmed against a live response. [Step 5](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/CREATING_AN_EXCHANGE_PLUGIN.md#step-5-amount-conversions) gains the same caveat, and both samples import `ceil` / `floor` so they compile as written.

The fix deliberately keeps the conversion as the main path rather than flipping to native. Most providers a plugin author integrates today still send display units, so a sample that assumed compliance would be wrong for the common case in the same way the current one is wrong for the compliant case.

The two documents have different jobs. [`API_REQUIREMENTS.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md) states what Edge asks a partner to send, so it can name one convention. The plugin guide states what plugin code does with what actually arrives, so it cannot. Each had drifted into the other's job: the guide hardcoded a convention, and section 3 had taken the plugin's conversion behavior and turned it into a demand on partners.

#### [`AGENTS.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/AGENTS.md) and [`.cursor/BUGBOT.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md)

[`AGENTS.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/AGENTS.md) named this doc as reading for evaluating a provider or arguing a gap back to them. It is now pre-implementation reading too, in the docs list and at the top of "Starting a new provider", where the useful form of the point is that a gap you are about to work around may be the provider's to fix rather than yours.

Both files also record what the doc is not. It states what Edge asks partners for, not what any given provider sends, and most existing integrations predate the request and send decimals. So it settles nothing in a units argument about a specific provider, where a live response still does. That guard goes in `AGENTS.md` under [Amount units](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/AGENTS.md#amount-units) and in `BUGBOT.md` under [`verify-amount-units`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md#L29), since both already carry the rule that a documented unit is not evidence.

Nothing else in either file needed changing. The plugin-side rounding rules ([`native-amounts-are-integers`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md#L8), [`limit-rounding-direction`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md#L23)) stay where they are; they describe what a plugin does with a limit, which is not a partner requirement and was the reason I kept that detail out of section 3.

#### Folded in from [#485](https://github.com/EdgeApp/edge-exchange-plugins/pull/485)

[#485](https://github.com/EdgeApp/edge-exchange-plugins/pull/485) drops its two documentation commits, and their content lands here instead. Neither hunk overlaps anything this PR already changed, so nothing had to be reconciled:

- [`API_REQUIREMENTS.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md) [section 4](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#4-quoting-requirements) gains a [**Rate types**](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/API_REQUIREMENTS.md#rate-types) subsection. Where a provider offers more than one rate type, the API must expose which types a route supports, so the client selects one rather than attempting a type and inferring support from the failure.
- [`BUGBOT.md`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md) gains three review rules: [`per-endpoint-auth`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md#L194), [`catalog-cache-expiry`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md#L201), and [`rate-type-fallback-scope`](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/.cursor/BUGBOT.md#L208).

The rate-types requirement is an addition, not a restoration, in the same category as the JSON-strings guidance above. Neither the source doc nor [#442](https://github.com/EdgeApp/edge-exchange-plugins/pull/442) mentions rate types, and it creates a new `must` on partners. The reasoning behind it: a provider that publishes rate types per asset but not per route leaves the client attempting a type and reading the failure, and a `5xx` for a route the provider cannot fix is indistinguishable from an outage.

The [StealthEX plugin](https://github.com/EdgeApp/edge-exchange-plugins/blob/jon/integrate-stealthex-swap/src/swap/central/stealthex.ts) on that branch confirms the [Step 6](https://github.com/EdgeApp/edge-exchange-plugins/blob/dddb7a1c41036c42e8ce67d80ac7833afa3f1c67/docs/CREATING_AN_EXCHANGE_PLUGIN.md#step-6-error-handling) fix rather than motivating it. It already rounds its below-limit with `ceil` and its above-limit with `floor`, which is what the corrected sample now shows and what the old one did not.

#### Prose pass

Both documents get a pass against the house writing rules, which neither had had. 16 em dashes are replaced with commas, colons or sentence breaks, including one inside a code comment that a fence hid from the linter. Gone with them: two "Additionally" openers, two "What matters is that" forward references, three count-announcement openers, "load-bearing", and a run of seven consecutive bullets that each carried mid-prose bold, so none of it landed. Headings move to sentence case in both files, and the plugin guide's opening line stops restating its own title. Its table of contents was also missing the pre-PR checklist.

The judgment-tier rules are the ones that mattered here. `no-slop-lint.sh` passed both files before most of the findings above, since it cannot see title case, bold density, a heading restated by the line under it, or an em dash inside a code fence. It returns clean on all four files now, and every in-document anchor still resolves after the heading changes.

#### What this keeps from `ff4cc3d`

Most of it. No sections were dropped, the bolded **must** count went 22 to 27, and sections 2, 5 and 7 got materially stricter and clearer. Everything here is a targeted revert of six items plus the units unification; the integration detail, the `StandardTx` status table, the `infoNeeded` requirement, and the edge-core-js error class mapping all stay.
