### PR TITLE
Require address-format handling from providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - added: A test suite for the swap plugin template, covering the max-quote probe, limit handling, the trust boundary on provider amounts, and memo cleaning. A new integration can copy it alongside the template.
 - changed: The swap plugin template now models the max-quote probe, the trust boundary on provider-returned amounts, integer native-amount rounding, and funds-safe memo cleaning, so a new integration starts from them rather than rediscovering them in review.
 - changed: `docs/CREATING_AN_EXCHANGE_PLUGIN.md` covers max quotes and amount rounding in depth, and ends with a pre-PR checklist drawn from findings on shipped integrations.
+- changed: `docs/API_REQUIREMENTS.md` requires providers to document which address formats they accept per chain, to accept every encoding of a format they do support rather than string-matching what the caller sent, to match EVM contract addresses case-insensitively, to keep their asset list in agreement with what the order endpoint accepts, both in chain identifiers and in availability, and to give a rejected address and a retryable failure their own error codes.
 
 ## 2.53.0 (2026-08-18)
 

--- a/docs/API_REQUIREMENTS.md
+++ b/docs/API_REQUIREMENTS.md
@@ -17,6 +17,7 @@ Field names and JSON shapes in this document are illustrative. The plugin layer 
 **General principles:**
 
 - [Amount representation](#amount-representation)
+- [Address formats](#address-formats)
 
 **Requirements for all providers:**
 
@@ -62,6 +63,40 @@ Edge swap plugins convert between native and display units using `denominationTo
 
 Every example in this document annotates its native amounts with the display equivalent in a trailing comment. The comments are documentation, not part of the payload.
 
+### Address formats
+
+Every address field in this document is a **user wallet address**: the payout destination, the refund address, and the deposit address the API returns. A wallet decides which address it hands out, and that choice is not something the client can override per provider, so the address reaching the API is whatever the user's wallet considers current.
+
+#### Document which formats you accept
+
+For each chain it supports, the API **must** document which address formats it accepts and which it does not.
+
+Partial coverage is acceptable. Formats are not equivalent amounts of work: a shielded chain's transparent, shielded and unified forms are different constructions, and a provider may reasonably support some and not others. Which formats a given provider covers, and by when, is a commercial matter settled per partner rather than by this document.
+
+What is **not** acceptable is leaving the gap undocumented. An unsupported format that is written down is an integration constraint the client can design around, by steering the user or by hiding the pair. The same gap undiscovered is a user whose swap failed for a reason nobody can explain.
+
+#### Accept every encoding of a format you do support
+
+Once the API accepts a format, it **must** accept every valid encoding of an address in that format. These are not separate formats to be supported one at a time; they are the same address written more than one way, and the difference is usually invisible to the person who copied it.
+
+- Compare addresses by decoding them according to the chain's rules, never by string equality on what the caller sent.
+- Do not pin a length or a checksum constant into validation. Lengths vary within a format, and chains revise checksums.
+
+The equivalences below are **examples, not a checklist**. Every chain defines its own, and a provider is responsible for those belonging to the chains it lists:
+
+| Axis | Example |
+|---|---|
+| Case | Bech32 is case-insensitive by [BIP-173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) and permits an all-uppercase encoding so QR codes can use alphanumeric mode. Hex EVM addresses are case-insensitive, with [EIP-55](https://eips.ethereum.org/EIPS/eip-55) mixed case carrying an optional checksum rather than identifying a different address. |
+| Alternate encodings of one account | Some chains publish an account in two encodings at once, such as a base58check form and a raw hex form. |
+| Optional prefixes | A scheme or network prefix the chain's own spec makes optional, so the same address is valid with and without it. |
+| Checksum revisions | Bech32m ([BIP-350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)) uses a different checksum constant from bech32 for witness version 1 and above, so a validator hardcoded to bech32 rejects every taproot address. |
+
+Bech32 and hex are named because they are the two that broke live integrations, not because they are the whole set. A provider that handles only these two and string-matches everything else has not met this requirement.
+
+#### Report a rejected address as its own error
+
+Rejecting an address **must** return its own machine-readable error code, distinct from the code for an unsupported pair (see [section 3](#3-error-handling)). Without that separation the client cannot tell an address the provider will not take from a chain it does not serve, and the user is shown the wrong reason. This is also what makes the documentation requirement above verifiable from the outside.
+
 ---
 
 ## Requirements for all providers
@@ -75,6 +110,21 @@ Edge exchange plugins maintain a mapping file (`src/mappings/<provider>.ts`) tha
 For EVM chains, the API **must** accept the standard numeric EVM `chainId` (e.g. `1` for Ethereum, `56` for BNB Smart Chain). Numeric chain ids let a newly listed EVM work the day it is added, with no new entry in the plugin's mapping file, and they avoid ambiguity with provider-specific EVM network names.
 
 For tokens, the API **must** accept the on-chain contract address (or equivalent identifier) to distinguish tokens on the same chain.
+
+Contract addresses **must** be matched case-insensitively wherever the chain's address encoding is case-insensitive, which covers every EVM chain. `0xdac17f958d2ee523a2206206994597c13d831ec7` and `0xdAC17F958D2ee523a2206206994597C13D831ec7` are the same token; the second simply carries an [EIP-55](https://eips.ethereum.org/EIPS/eip-55) checksum. Matching the raw string means whether a token resolves depends on which casing the caller happened to hold, and a provider whose own asset list mixes the two casings will serve some tokens and not others for no reason the caller can see.
+
+#### The asset list must agree with order behavior
+
+The "list all assets" endpoint is what an integrator builds the mapping from, so it **must** describe what the order endpoint will actually accept, in two respects.
+
+**Same identifiers.** Whatever identifiers the quote and order endpoints accept **must** be documented, and the list **must** report assets using those same identifiers.
+
+- A chain named one way in the list and another way at the order endpoint cannot be mapped from the API at all. It has to be guessed by hand, and chains then fall out of the mapping silently as the provider adds them.
+- An asset whose list entry omits the identifier the order endpoint requires cannot be ordered from list data at all. A list keyed by ticker is not a substitute when the order endpoint takes a contract address: the entry is advertised as available while carrying nothing an order can be built from.
+
+**Same availability.** An asset or pair the list reports as available **must not** be refused by the order endpoint as unsupported, and an asset the order endpoint serves **should** appear in the list. Where availability is genuinely dynamic (a temporary halt, a liquidity or maintenance window), the list **must** carry that state in a machine-readable field rather than continuing to advertise the asset, and the order endpoint **must** distinguish a temporary halt from an unsupported asset by error code (see [section 3](#3-error-handling)).
+
+A list that advertises assets the order endpoint rejects is worse than no list. It reads as a supported-asset inventory, an integrator maps every entry in it, and every one of those mappings that does not work becomes a pair the user is offered and cannot complete.
 
 **Example: non-EVM asset**
 
@@ -114,6 +164,10 @@ The plugin maps provider errors to these Edge error classes (defined in `edge-co
 | Asset/pair not supported | `SwapCurrencyError` | A machine-readable code identifying which asset(s) are unsupported |
 | Amount too low | `SwapBelowLimitError` | The minimum amount in **both** the source asset and the destination asset |
 | Amount too high | `SwapAboveLimitError` | The maximum amount in **both** the source asset and the destination asset |
+| Address not accepted | `SwapCurrencyError` (until a dedicated class exists) | A machine-readable code identifying which address was rejected, distinct from an unsupported pair |
+| Transient or retryable failure | retried, then surfaced as a generic failure | A machine-readable code marking the failure as retryable rather than permanent |
+
+A code **must** identify one condition. Reusing a single code across distinct conditions is the same defect as returning an unstructured string: the client can read it, but it does not mean anything specific enough to act on. Two conditions this matters most for are the last two rows above. An address the provider will not accept, and a creation failure that would succeed on retry, both differ from "this pair is unsupported", and a client that cannot tell them apart will report a permanent limitation for a problem that is neither permanent nor about the pair.
 
 #### Why both source and destination limits are needed
 


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Documentation only. No plugin code changes.

Three address-handling defects turned up while investigating Xgram and SimpleSwap against their live APIs ([Asana](https://app.asana.com/0/1215088146871429/1217836790411372)). Each was permitted by the spec as written, and each one reaches the user as a swap that cannot be quoted:

| Defect | Xgram | SimpleSwap |
|---|---|---|
| A standardized format rejected outright | bech32 Litecoin (`ltc1...`) refused, legacy and P2SH accepted | unified Zcash (`u1...`) refused, transparent and TEX accepted |
| A case variant treated as a different address | all-uppercase bech32 refused | `validationAddress` regexes match lowercase prefixes only |
| A length pinned into validation | n/a | `^(ltc1)[0-9A-Za-z]{39}$` excludes longer P2WSH and bech32m forms |

In both format-rejection cases the refused form is the one the Edge wallet hands out by default for that chain, so the pair fails for every user rather than some of them. Neither provider returns a distinct error code for it, so the rejection is indistinguishable from an unsupported pair and the user is told the pair is not supported.

This adds:

- **A new `Address formats` general principle**, split into two requirements of deliberately different weight. **Format coverage may be partial** and must be documented per chain: transparent, shielded and unified are different constructions, and a provider may reasonably support some and not others, so what the spec demands is that the gap is written down rather than discovered by a failed swap. **Encoding equivalence is not optional**: once a format is accepted, every valid encoding of an address in it is the same address, compared by decoding rather than by string equality, with no length or checksum constant pinned into validation. Case, optional prefixes, alternate account encodings and checksum revisions (bech32m for taproot) appear as examples rather than as the list.
- **Case-insensitive contract matching, in section 1.** Xgram resolves `0xdac17f9...` and refuses `0xdAC17F9...` for the same token, and its own asset list returns a mix of both casings. Section 1 also now requires the asset-list endpoint to name chains using the identifiers the quote endpoint expects. Xgram's differ (`Litecoin` in the list, `LTC` at the endpoint), which is why Litecoin and Stellar were never mapped on our side.
- **Two rows and a no-overloading rule, in section 3.** An unacceptable address and a retryable failure each need their own machine-readable code. Xgram currently returns `CURRENCY_UNSUPPORTED` for at least five distinct conditions, which is what collapses all of the above into "No enabled exchanges support X to Y".

Asset coverage stays a per-partner commercial matter and is deliberately not restated here. The Zcash unified-address requirement, for one, is already an Exhibit A term for SimpleSwap, and enumerating chains in this doc would imply the list is the requirement.

Section numbering is unchanged, so the `#3-error-handling` deep links already shared with partners still resolve.
