### PR TITLE
Surface Xgram transport refusals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - added: Robinhood Chain swaps via SideShift, LI.FI, Rango, ChangeNow, Swapuz and LetsExchange.
+- fixed: Xgram now reports a rejected API key as `Xgram: HTTP 401 Unauthorized` instead of a cleaner type error, and stops retrying such a refusal as a float order.
 
 ## 2.54.0 (2026-08-28)
 

--- a/src/swap/central/xgram.ts
+++ b/src/swap/central/xgram.ts
@@ -3,6 +3,7 @@ import {
   asDate,
   asEither,
   asMaybe,
+  asNumber,
   asObject,
   asOptional,
   asString,
@@ -73,11 +74,30 @@ const addressTypeMap: StringMap = {
 type XgramRateType = 'fixed' | 'float'
 const ccyAmountLimitRegex = /ccyAmount must be ([><])\s*([\d.]+)/
 
-const isTypedSwapError = (error: unknown): boolean =>
+/**
+ * Xgram answers a rejected key, and its other transport-level refusals, with an
+ * HTTP 200 whose body is `{"status":401,"message":"Unauthorized"}`. That shape
+ * matches none of the quote cleaners, so without a branch of its own the reply
+ * surfaces as `Expected a string, got undefined at .error`, which reads like a
+ * plugin bug instead of the API turning us away.
+ */
+class XgramStatusError extends Error {
+  name = 'XgramStatusError'
+  constructor(status: number, message: string) {
+    super(`Xgram: HTTP ${status} ${message}`)
+  }
+}
+
+/**
+ * Errors that apply to both rate types, so the float retry in `swapExchange`
+ * cannot clear them and would only double the failed calls.
+ */
+const isNonRetryableError = (error: unknown): boolean =>
   error instanceof SwapAboveLimitError ||
   error instanceof SwapBelowLimitError ||
   error instanceof SwapCurrencyError ||
-  error instanceof SwapPermissionError
+  error instanceof SwapPermissionError ||
+  error instanceof XgramStatusError
 
 export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
   const { io } = opts
@@ -159,6 +179,10 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
       })
       const quoteFor = request.quoteFor === 'from' ? 'from' : 'to'
       const quoteReply = asXgramQuoteReply(orderResponseJson)
+
+      if ('status' in quoteReply) {
+        throw new XgramStatusError(quoteReply.status, quoteReply.message)
+      }
 
       if ('errors' in quoteReply) {
         const errors = quoteReply.errors
@@ -254,16 +278,16 @@ export function makeXgramPlugin(opts: EdgeCorePluginOptions): EdgeSwapPlugin {
 
       // Xgram intermittently rejects every fixed-rate creation provider-side
       // with a generic "Error while creating exchange", so fall back to a
-      // float-rate order when the fixed-rate attempt fails. Typed swap errors
-      // (limits, unsupported pair, geo restriction) apply to both rate types
-      // and are rethrown without a retry. Float orders lock no rate, so the
-      // resulting quote is flagged as an estimate.
+      // float-rate order when the fixed-rate attempt fails. Errors that apply
+      // to both rate types (limits, unsupported pair, geo restriction, and the
+      // transport-level refusals above) are rethrown without a retry. Float
+      // orders lock no rate, so the resulting quote is flagged as an estimate.
       let order: XgramResponse
       let isEstimate = false
       try {
         order = await createOrder(isSelling, largeDenomAmount, 'fixed')
       } catch (error: unknown) {
-        if (isTypedSwapError(error)) throw error
+        if (isNonRetryableError(error)) throw error
         order = await createOrder(isSelling, largeDenomAmount, 'float')
         isEstimate = true
       }
@@ -413,6 +437,10 @@ const asXgramError = asObject({
 const asXgramStringError = asObject({
   error: asString
 })
+const asXgramStatusError = asObject({
+  message: asString,
+  status: asNumber
+})
 const asXgramQuote = asObject({
   ccyAmountToExpected: asOptional(asNumberString),
   depositAddress: asString,
@@ -425,5 +453,6 @@ const asXgramQuote = asObject({
 const asXgramQuoteReply = asEither(
   asXgramQuote,
   asXgramError,
-  asXgramStringError
+  asXgramStringError,
+  asXgramStatusError
 )

--- a/test/xgram.test.ts
+++ b/test/xgram.test.ts
@@ -1,0 +1,126 @@
+import { assert } from 'chai'
+import {
+  EdgeCorePluginOptions,
+  EdgeCurrencyWallet,
+  EdgeSwapPlugin,
+  EdgeSwapRequest
+} from 'edge-core-js/types'
+import { describe, it } from 'mocha'
+
+import { makeXgramPlugin } from '../src/swap/central/xgram'
+
+/**
+ * Xgram reports a rejected API key as an HTTP 200 carrying
+ * `{"status":401,"message":"Unauthorized"}`, measured against the live API on
+ * 2026-09-03 when our partner key stopped being accepted.
+ */
+const UNAUTHORIZED_BODY = { status: 401, message: 'Unauthorized' }
+
+const BTC_ADDRESS = 'bc1q6aas41krwvvcc4hhio6u4euf1y3wkbtap8uhmrt'
+const SOL_ADDRESS = 'fnW7xCjkTG9XY7pG9NhBhoAN3NsLVJR5y3nfax1yQwg'
+const BTC_MULTIPLIER = '100000000'
+const SOL_MULTIPLIER = '1000000000'
+
+const makeFakeWallet = (
+  pluginId: string,
+  currencyCode: string,
+  address: string,
+  multiplier: string
+): EdgeCurrencyWallet => {
+  const currencyInfo = {
+    pluginId,
+    currencyCode,
+    denominations: [{ name: currencyCode, multiplier }]
+  }
+
+  return ({
+    id: `${pluginId}-wallet`,
+    currencyInfo,
+    currencyConfig: {
+      // `SwapCurrencyError` reads the pluginId through here.
+      currencyInfo,
+      allTokens: {}
+    },
+    async getAddresses() {
+      return [{ addressType: 'publicAddress', publicAddress: address }]
+    }
+  } as unknown) as EdgeCurrencyWallet
+}
+
+const makePlugin = (body: unknown, requestLog: string[]): EdgeSwapPlugin => {
+  const fetch = async (uri: string): Promise<unknown> => {
+    requestLog.push(uri)
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body)
+    }
+  }
+
+  return makeXgramPlugin(({
+    io: { fetch, fetchCors: fetch },
+    initOptions: { apiKey: 'test-key' },
+    log: Object.assign(() => {}, { warn() {} })
+  } as unknown) as EdgeCorePluginOptions)
+}
+
+const makeRequest = (): EdgeSwapRequest => ({
+  fromWallet: makeFakeWallet('bitcoin', 'BTC', BTC_ADDRESS, BTC_MULTIPLIER),
+  fromTokenId: null,
+  toWallet: makeFakeWallet('solana', 'SOL', SOL_ADDRESS, SOL_MULTIPLIER),
+  toTokenId: null,
+  nativeAmount: '1000000',
+  quoteFor: 'from'
+})
+
+describe('xgram transport errors', function () {
+  it('names the status and message Xgram sent back', async function () {
+    // Regression shape: the `{status, message}` body matched none of the quote
+    // cleaners, so the union threw `Expected a string, got undefined at .error`
+    // and the real cause never reached the logs.
+    const requestLog: string[] = []
+    const plugin = makePlugin(UNAUTHORIZED_BODY, requestLog)
+
+    let thrown: unknown
+    try {
+      await plugin.fetchSwapQuote(makeRequest(), undefined, { infoPayload: {} })
+    } catch (error: unknown) {
+      thrown = error
+    }
+
+    assert.isTrue(thrown instanceof Error)
+    assert.equal((thrown as Error).name, 'XgramStatusError')
+    assert.equal((thrown as Error).message, 'Xgram: HTTP 401 Unauthorized')
+  })
+
+  it('does not retry a transport refusal as a float order', async function () {
+    // The float fallback exists for fixed-rate-only failures. A refusal that
+    // precedes rate handling fails the same way twice, so retrying it only
+    // doubles the load Xgram has asked us to reduce.
+    const requestLog: string[] = []
+    const plugin = makePlugin(UNAUTHORIZED_BODY, requestLog)
+
+    await plugin
+      .fetchSwapQuote(makeRequest(), undefined, { infoPayload: {} })
+      .catch(() => undefined)
+
+    assert.equal(requestLog.length, 1)
+    assert.include(requestLog[0], 'type=fixed')
+  })
+
+  it('still falls back to float on a rate-type failure', async function () {
+    const requestLog: string[] = []
+    const plugin = makePlugin(
+      { result: false, error: 'Error while creating exchange' },
+      requestLog
+    )
+
+    await plugin
+      .fetchSwapQuote(makeRequest(), undefined, { infoPayload: {} })
+      .catch(() => undefined)
+
+    assert.equal(requestLog.length, 2)
+    assert.include(requestLog[1], 'type=float')
+  })
+})


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

none

### Description

Xgram answers a rejected API key with an HTTP 200 whose body is
`{"status":401,"message":"Unauthorized"}`. That shape matches none of the quote
cleaners, so the plugin's cleaner union threw
`TypeError: Expected a string, got undefined at .error`, and the real cause never
reached the logs or the user. The plugin also retried the same refusal as a
float order, doubling the failed calls against an endpoint Xgram has separately
asked us to call less.

This adds a cleaner branch for that envelope, throws
`Xgram: HTTP <status> <message>` instead, and classifies it as non-retryable so
the float fallback stays scoped to the fixed-rate-only failures it exists for.
The rename from `isTypedSwapError` to `isNonRetryableError` reflects that the
guard now covers both.

Found while re-testing Xgram's API for
[the partner comms task](https://app.asana.com/0/1215088146871429/1218117826000804):
our partner key is currently rejected on every Xgram endpoint, so the app hits
this path on every Xgram quote today.

Tests: three unit cases cover the named error, the absent retry, and the float
fallback still firing on a rate-type failure.
